### PR TITLE
chore: fix wrong com.lancedb package in Hive2 and Hive3 Namespace

### DIFF
--- a/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
+++ b/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
@@ -455,11 +455,11 @@ public class Hive2Namespace implements LanceNamespace {
       StorageDescriptor sd = new StorageDescriptor();
       sd.setLocation(location);
       sd.setCols(Lists.newArrayList());
-      sd.setInputFormat("com.lancedb.lance.mapred.LanceInputFormat");
-      sd.setOutputFormat("com.lancedb.lance.mapred.LanceOutputFormat");
+      sd.setInputFormat("org.lance.mapred.LanceInputFormat");
+      sd.setOutputFormat("org.lance.mapred.LanceOutputFormat");
       org.apache.hadoop.hive.metastore.api.SerDeInfo serdeInfo =
           new org.apache.hadoop.hive.metastore.api.SerDeInfo();
-      serdeInfo.setSerializationLib("com.lancedb.lance.mapred.LanceSerDe");
+      serdeInfo.setSerializationLib("org.lance.mapred.LanceSerDe");
       sd.setSerdeInfo(serdeInfo);
       table.setSd(sd);
 

--- a/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
+++ b/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
@@ -512,8 +512,8 @@ public class Hive3Namespace implements LanceNamespace {
       StorageDescriptor sd = new StorageDescriptor();
       sd.setLocation(location);
       sd.setCols(Lists.newArrayList());
-      sd.setInputFormat("com.lancedb.lance.mapred.LanceInputFormat");
-      sd.setOutputFormat("com.lancedb.lance.mapred.LanceOutputFormat");
+      sd.setInputFormat("org.lance.mapred.LanceInputFormat");
+      sd.setOutputFormat("org.lance.mapred.LanceOutputFormat");
       sd.setSerdeInfo(new org.apache.hadoop.hive.metastore.api.SerDeInfo());
       table.setSd(sd);
 


### PR DESCRIPTION
chore: fix wrong com.lancedb package in Hive2 and Hive3 Namespace.