### PR TITLE
ci: add workflow to auto-bump lance-core version

### DIFF
--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Codex Update Lance Dependency
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag name from Lance (e.g., v2.0.0)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name from Lance (e.g., v2.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show inputs
+        run: |
+          echo "tag = ${{ inputs.tag }}"
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install packaging lxml
+
+      - name: Configure git user
+        run: |
+          git config user.name "lance-community"
+          git config user.email "community@lance.org"
+
+      - name: Run Codex to update Lance dependency
+        env:
+          TAG: ${{ inputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.CODEX_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#refs/tags/}"
+          VERSION="${VERSION#v}"
+          BRANCH_NAME="codex/update-lance-${VERSION//[^a-zA-Z0-9]/-}"
+
+          cat <<EOF >/tmp/codex-prompt.txt
+          You are running inside the lance-namespace-impls repository on a GitHub Actions runner. Update the Lance dependency to version ${VERSION} (semver format) and prepare a pull request for maintainers to review.
+
+          Follow these steps exactly:
+          1. Update the lance-core.version property in java/pom.xml. Find the line "<lance-core.version>X.Y.Z...</lance-core.version>" in the properties section and update it to "<lance-core.version>${VERSION}</lance-core.version>".
+          2. Run "cd java && make lint" to check for any linting issues. If there are issues, run "cd java && ./mvnw spotless:apply" to fix them and rerun the lint check until it passes.
+          3. Run "cd java && make build" to verify the build works with the new dependency.
+          4. Inspect "git status --short" and "git diff" to confirm the dependency update and any required fixes.
+          5. Create and switch to a new branch named "${BRANCH_NAME}" (replace any duplicated hyphens if necessary).
+          6. Stage all relevant files with "git add -A". Commit using the message "chore: update lance-core dependency to v${VERSION}".
+          7. Push the branch to origin. If the remote branch already exists, delete it first with "gh api -X DELETE repos/lance-format/lance-namespace-impls/git/refs/heads/${BRANCH_NAME}" then push with "git push origin ${BRANCH_NAME}". Do NOT use "git push --force" or "git push -f".
+          8. env "GH_TOKEN" is available, use "gh" tools for github related operations like creating pull request.
+          9. Create a pull request targeting "main" with title "chore: update lance-core dependency to v${VERSION}". First, write the PR body to /tmp/pr-body.md using a heredoc (cat <<'EOF' > /tmp/pr-body.md). The body should summarize the dependency bump, build verification, and link the triggering tag (${TAG}). Then run "gh pr create --body-file /tmp/pr-body.md".
+          10. Display the PR URL, "git status --short", and a concise summary of the commands run and their results.
+
+          Constraints:
+          - Use bash commands; avoid modifying GitHub workflow files other than through the scripted task above.
+          - Do not merge the PR.
+          - If any command fails, diagnose and fix the issue instead of aborting.
+          - For lance-core compatibility errors, checkout lance-format/lance for source code reference.
+          - For lance-namespace compatibility errors, checkout lance-format/lance-namespace for source code reference.
+          EOF
+
+          printenv OPENAI_API_KEY | codex login --with-api-key
+          codex --config shell_environment_policy.ignore_default_excludes=true exec --dangerously-bypass-approvals-and-sandbox "$(cat /tmp/codex-prompt.txt)"

--- a/.github/workflows/lance-release-timer.yml
+++ b/.github/workflows/lance-release-timer.yml
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lance Release Timer
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: lance-release-timer
+  cancel-in-progress: false
+
+jobs:
+  trigger-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install lxml
+
+      - name: Check for new Lance tag
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          python3 ci/check_lance_release.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Look for existing PR
+        if: steps.check.outputs.needs_update == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: update lance-core dependency to v${{ steps.check.outputs.latest_version }}"
+          COUNT=$(gh pr list --search "\"$TITLE\" in:title" --state open --limit 1 --json number --jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Open PR already exists for $TITLE"
+            echo "pr_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No existing PR for $TITLE"
+            echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger codex update workflow
+        if: steps.check.outputs.needs_update == 'true' && steps.pr.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG=${{ steps.check.outputs.latest_tag }}
+          gh workflow run codex-update-lance-dependency.yml -f tag=refs/tags/$TAG
+
+      - name: Show latest codex workflow run
+        if: steps.check.outputs.needs_update == 'true' && steps.pr.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh run list --workflow codex-update-lance-dependency.yml --limit 1 --json databaseId,url,displayTitle

--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Determine whether a newer Lance tag exists and expose results for CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from lxml import etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+LANCE_REPO = "lance-format/lance"
+
+SEMVER_RE = re.compile(
+    r"^\s*(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?\s*$"
+)
+
+
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[int | str, ...]
+
+    def __lt__(self, other: SemVer) -> bool:
+        if (self.major, self.minor, self.patch) != (
+            other.major,
+            other.minor,
+            other.patch,
+        ):
+            return (self.major, self.minor, self.patch) < (
+                other.major,
+                other.minor,
+                other.patch,
+            )
+        if self.prerelease == other.prerelease:
+            return False
+        if not self.prerelease:
+            return False  # release > anything else
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            if isinstance(left, int) and isinstance(right, int):
+                return left < right
+            if isinstance(left, int):
+                return True
+            if isinstance(right, int):
+                return False
+            return str(left) < str(right)
+        return len(self.prerelease) < len(other.prerelease)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and self.patch == other.patch
+            and self.prerelease == other.prerelease
+        )
+
+
+def parse_semver(raw: str) -> SemVer:
+    match = SEMVER_RE.match(raw)
+    if not match:
+        raise ValueError(f"Unsupported version format: {raw}")
+    prerelease = match.group("prerelease")
+    parts: tuple[int | str, ...] = ()
+    if prerelease:
+        parsed: list[int | str] = []
+        for piece in prerelease.split("."):
+            if piece.isdigit():
+                parsed.append(int(piece))
+            else:
+                parsed.append(piece)
+        parts = tuple(parsed)
+    return SemVer(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=parts,
+    )
+
+
+@dataclass
+class TagInfo:
+    tag: str  # e.g. v1.0.0-beta.2
+    version: str  # e.g. 1.0.0-beta.2
+    semver: SemVer
+
+
+def run_command(cmd: Sequence[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def fetch_remote_tags() -> list[TagInfo]:
+    output = run_command(
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            f"repos/{LANCE_REPO}/git/refs/tags",
+            "--paginate",
+            "--jq",
+            ".[].ref",
+        ]
+    )
+    tags: list[TagInfo] = []
+    for line in output.splitlines():
+        ref = line.strip()
+        if not ref.startswith("refs/tags/v"):
+            continue
+        tag = ref.split("refs/tags/")[-1]
+        version = tag.lstrip("v")
+        try:
+            tags.append(TagInfo(tag=tag, version=version, semver=parse_semver(version)))
+        except ValueError:
+            continue
+    if not tags:
+        raise RuntimeError("No Lance tags could be parsed from GitHub API output")
+    return tags
+
+
+def read_current_version(repo_root: Path) -> str:
+    """Read lance-core.version from java/pom.xml."""
+    pom_path = repo_root / "java" / "pom.xml"
+    tree = etree.parse(str(pom_path))
+    root = tree.getroot()
+
+    ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+    lance_version_elem = root.find(".//m:properties/m:lance-core.version", ns)
+
+    if lance_version_elem is None or lance_version_elem.text is None:
+        raise RuntimeError("Failed to locate lance-core.version property in pom.xml")
+
+    return lance_version_elem.text.strip()
+
+
+def determine_latest_tag(tags: Iterable[TagInfo]) -> TagInfo:
+    return max(tags, key=lambda tag: tag.semver)
+
+
+def write_outputs(args: argparse.Namespace, payload: dict) -> None:
+    target = getattr(args, "github_output", None)
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for key, value in payload.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Path to the lance-namespace-impls repository root",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Optional file path for writing GitHub Action outputs",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    current_version = read_current_version(repo_root)
+    current_semver = parse_semver(current_version)
+
+    tags = fetch_remote_tags()
+    latest = determine_latest_tag(tags)
+    needs_update = latest.semver > current_semver
+
+    payload = {
+        "current_version": current_version,
+        "current_tag": f"v{current_version}",
+        "latest_version": latest.version,
+        "latest_tag": latest.tag,
+        "needs_update": "true" if needs_update else "false",
+    }
+
+    print(json.dumps(payload))
+    write_outputs(args, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `lance-release-timer.yml` workflow that runs every 10 minutes to check for new lance releases
- Add `codex-update-lance-dependency.yml` workflow that uses OpenAI Codex to update lance-core version and create PRs
- Add `ci/check_lance_release.py` script to detect new lance-core versions from lance-format/lance

## Required Secrets

- `LANCE_RELEASE_TOKEN` - GitHub token with repo access
- `CODEX_TOKEN` - OpenAI API key for Codex CLI

## How it works

1. Timer workflow runs every 10 minutes
2. Checks lance-format/lance for new tags
3. Compares against current `lance-core.version` in `java/pom.xml`
4. If a newer version exists and no PR is open, triggers the Codex update workflow
5. Codex updates the pom.xml, runs lint/build, and creates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)