### PR TITLE
feat: update lance-core dependency to v2.0.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0-rc.3</lance-core.version>
+        <lance-core.version>2.0.0</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- bump lance-core dependency to v2.0.0
- build verified with `cd java && make lint` and `cd java && make build`
- triggering tag: v2.0.0
