### PR TITLE
chore: update lance-core dependency to v3.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>3.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump `lance-core` to `3.0.0-beta.4`.
- Verified `make lint` and `make build` in `java/` (build uses local install of `lance-core` from `refs/tags/v3.0.0-beta.4`).

## Link
- `refs/tags/v3.0.0-beta.4`
