### PR TITLE
chore: update lance-core dependency to v3.0.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>3.0.0-beta.5</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump `lance-core` to `3.0.0-beta.5`.
- Verification used local install from `refs/tags/v3.0.0-beta.5` to satisfy Maven since the artifact is not yet in Maven Central.

## Testing
- `cd java && make lint`
- `cd java && make build`

## Release
- `refs/tags/v3.0.0-beta.5`
