### PR TITLE
chore: update lance-core dependency to v3.0.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>3.0.0-rc.1</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump `lance-core` dependency to `3.0.0-rc.1`.

## Testing
- `cd java && make lint`
- `cd java && make build` (fails: `org.lance:lance-core:3.0.0-rc.1` not found on Maven Central)

## Release
- refs/tags/v3.0.0-rc.1
