### PR TITLE
chore: update lance-core dependency to v3.1.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>3.1.0-beta.1</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bumped `lance-core` to `3.1.0-beta.1`.
- Verified `make lint` and `make build` in `java/` (after installing `lance-core` from tag `refs/tags/v3.1.0-beta.1` into the local Maven repo because the artifact is not yet on Maven Central).

## References
- Triggering tag: `refs/tags/v3.1.0-beta.1`
