### PR TITLE
chore: update lance-core dependency to v4.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.0.0-beta.4`
- verify formatting and lint with `cd java && make lint`
- verify build with `cd java && make build`

## Notes
- `make build` initially failed because `org.lance:lance-core:4.0.0-beta.4` is not available in Maven Central on this runner.
- to complete verification, I built and installed `lance-core` locally from `lance-format/lance` tag `refs/tags/v4.0.0-beta.4`, then reran `make build` successfully.

Triggering tag: `refs/tags/v4.0.0-beta.4`
