### PR TITLE
feat: add "ThreeLevelNamespaceAdapter" for enforcing 3-level table identifiers

### DIFF
--- a/java/lance-namespace-impls-core/src/main/java/org/lance/namespace/util/ThreeLevelNamespaceAdapter.java
+++ b/java/lance-namespace-impls-core/src/main/java/org/lance/namespace/util/ThreeLevelNamespaceAdapter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.util;
+
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.errors.InvalidInputException;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+
+import org.apache.arrow.memory.BufferAllocator;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapter that enforces exactly 3 levels for table identifiers and 2 levels for namespace
+ * identifiers.
+ *
+ * <p>This adapter wraps any {@link LanceNamespace} implementation and validates that:
+ *
+ * <ul>
+ *   <li>Table identifiers have exactly 3 levels: [catalog, database, table]
+ *   <li>Namespace identifiers have at most 2 levels: [catalog] or [catalog, database]
+ *   <li>Operations on non-conforming identifiers are rejected with {@link InvalidInputException}
+ * </ul>
+ *
+ * <p>This is useful for namespace implementations that need to enforce a strict 3-level hierarchy
+ * (e.g., Unity Catalog, Gravitino) while allowing the underlying implementation to be more
+ * flexible.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * LanceNamespace underlying = new SomeNamespace();
+ * LanceNamespace enforced = new ThreeLevelNamespaceAdapter(underlying);
+ * enforced.initialize(properties, allocator);
+ * }</pre>
+ */
+public class ThreeLevelNamespaceAdapter implements LanceNamespace {
+
+  private final LanceNamespace delegate;
+
+  public ThreeLevelNamespaceAdapter(LanceNamespace delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
+    delegate.initialize(configProperties, allocator);
+  }
+
+  @Override
+  public String namespaceId() {
+    return "ThreeLevelNamespaceAdapter { delegate: " + delegate.namespaceId() + " }";
+  }
+
+  @Override
+  public ListNamespacesResponse listNamespaces(ListNamespacesRequest request) {
+    validateNamespaceId(request.getId(), "list");
+    return delegate.listNamespaces(request);
+  }
+
+  @Override
+  public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
+    validateNamespaceId(request.getId(), "create");
+    return delegate.createNamespace(request);
+  }
+
+  @Override
+  public DescribeNamespaceResponse describeNamespace(DescribeNamespaceRequest request) {
+    validateNamespaceId(request.getId(), "describe");
+    return delegate.describeNamespace(request);
+  }
+
+  @Override
+  public DropNamespaceResponse dropNamespace(DropNamespaceRequest request) {
+    validateNamespaceId(request.getId(), "drop");
+    return delegate.dropNamespace(request);
+  }
+
+  @Override
+  public ListTablesResponse listTables(ListTablesRequest request) {
+    validateNamespaceId(request.getId(), "list tables in");
+    return delegate.listTables(request);
+  }
+
+  @Override
+  public DeclareTableResponse declareTable(DeclareTableRequest request) {
+    validateTableId(request.getId());
+    return delegate.declareTable(request);
+  }
+
+  @Override
+  public DescribeTableResponse describeTable(DescribeTableRequest request) {
+    validateTableId(request.getId());
+    return delegate.describeTable(request);
+  }
+
+  @Override
+  public DeregisterTableResponse deregisterTable(DeregisterTableRequest request) {
+    validateTableId(request.getId());
+    return delegate.deregisterTable(request);
+  }
+
+  /**
+   * Validates that a namespace identifier has at most 2 levels.
+   *
+   * @param id the namespace identifier to validate
+   * @param operation the operation being performed (for error messages)
+   * @throws InvalidInputException if the identifier has more than 2 levels
+   */
+  private void validateNamespaceId(List<String> id, String operation) {
+    if (id == null) {
+      return; // Root namespace is allowed
+    }
+
+    int levels = id.size();
+    if (levels > 2) {
+      throw new InvalidInputException(
+          String.format(
+              "Cannot %s namespace with %d levels. Expected at most 2 levels (catalog.database), but got: %s",
+              operation, levels, String.join(".", id)),
+          "INVALID_NAMESPACE_LEVELS",
+          String.join(".", id));
+    }
+  }
+
+  /**
+   * Validates that a table identifier has exactly 3 levels.
+   *
+   * @param id the table identifier to validate
+   * @throws InvalidInputException if the identifier does not have exactly 3 levels
+   */
+  private void validateTableId(List<String> id) {
+    if (id == null || id.size() != 3) {
+      String idStr = id != null ? String.join(".", id) : "null";
+      int levels = id != null ? id.size() : 0;
+      throw new InvalidInputException(
+          String.format(
+              "Table identifier must have exactly 3 levels (catalog.database.table), but got %d levels: %s",
+              levels, idStr),
+          "INVALID_TABLE_LEVELS",
+          idStr);
+    }
+
+    // Validate that no level is null or empty
+    for (int i = 0; i < id.size(); i++) {
+      String level = id.get(i);
+      if (level == null || level.isEmpty()) {
+        throw new InvalidInputException(
+            String.format(
+                "Table identifier level %d cannot be null or empty: %s", i, String.join(".", id)),
+            "INVALID_TABLE_IDENTIFIER",
+            String.join(".", id));
+      }
+    }
+  }
+}

--- a/java/lance-namespace-impls-core/src/test/java/org/lance/namespace/util/TestThreeLevelNamespaceAdapter.java
+++ b/java/lance-namespace-impls-core/src/test/java/org/lance/namespace/util/TestThreeLevelNamespaceAdapter.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.util;
+
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.errors.InvalidInputException;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestThreeLevelNamespaceAdapter {
+
+  private BufferAllocator allocator;
+  private LanceNamespace mockDelegate;
+  private ThreeLevelNamespaceAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    allocator = new RootAllocator();
+    mockDelegate = mock(LanceNamespace.class);
+    adapter = new ThreeLevelNamespaceAdapter(mockDelegate);
+  }
+
+  @AfterEach
+  void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  void testInitialize() {
+    Map<String, String> config = Collections.singletonMap("key", "value");
+    adapter.initialize(config, allocator);
+    verify(mockDelegate).initialize(config, allocator);
+  }
+
+  @Test
+  void testNamespaceId() {
+    when(mockDelegate.namespaceId()).thenReturn("MockNamespace");
+    String id = adapter.namespaceId();
+    assertTrue(id.contains("ThreeLevelNamespaceAdapter"));
+    assertTrue(id.contains("MockNamespace"));
+  }
+
+  // Namespace operations tests
+
+  @Test
+  void testListNamespacesWithRootId() {
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    request.setId(null);
+
+    ListNamespacesResponse response = new ListNamespacesResponse();
+    when(mockDelegate.listNamespaces(request)).thenReturn(response);
+
+    assertEquals(response, adapter.listNamespaces(request));
+    verify(mockDelegate).listNamespaces(request);
+  }
+
+  @Test
+  void testListNamespacesWithOneLevelId() {
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    request.setId(Collections.singletonList("catalog"));
+
+    ListNamespacesResponse response = new ListNamespacesResponse();
+    when(mockDelegate.listNamespaces(request)).thenReturn(response);
+
+    assertEquals(response, adapter.listNamespaces(request));
+    verify(mockDelegate).listNamespaces(request);
+  }
+
+  @Test
+  void testListNamespacesWithTwoLevelId() {
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    request.setId(Arrays.asList("catalog", "database"));
+
+    ListNamespacesResponse response = new ListNamespacesResponse();
+    when(mockDelegate.listNamespaces(request)).thenReturn(response);
+
+    assertEquals(response, adapter.listNamespaces(request));
+    verify(mockDelegate).listNamespaces(request);
+  }
+
+  @Test
+  void testListNamespacesWithThreeLevelIdFails() {
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    request.setId(Arrays.asList("catalog", "database", "table"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.listNamespaces(request));
+
+    assertTrue(exception.getMessage().contains("3 levels"));
+    assertTrue(exception.getMessage().contains("at most 2 levels"));
+    verify(mockDelegate, never()).listNamespaces(any());
+  }
+
+  @Test
+  void testCreateNamespaceWithValidId() {
+    CreateNamespaceRequest request = new CreateNamespaceRequest();
+    request.setId(Arrays.asList("catalog", "database"));
+
+    CreateNamespaceResponse response = new CreateNamespaceResponse();
+    when(mockDelegate.createNamespace(request)).thenReturn(response);
+
+    assertEquals(response, adapter.createNamespace(request));
+    verify(mockDelegate).createNamespace(request);
+  }
+
+  @Test
+  void testCreateNamespaceWithInvalidIdFails() {
+    CreateNamespaceRequest request = new CreateNamespaceRequest();
+    request.setId(Arrays.asList("catalog", "database", "extra"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.createNamespace(request));
+
+    assertTrue(exception.getMessage().contains("3 levels"));
+    verify(mockDelegate, never()).createNamespace(any());
+  }
+
+  @Test
+  void testDescribeNamespace() {
+    DescribeNamespaceRequest request = new DescribeNamespaceRequest();
+    request.setId(Collections.singletonList("catalog"));
+
+    DescribeNamespaceResponse response = new DescribeNamespaceResponse();
+    when(mockDelegate.describeNamespace(request)).thenReturn(response);
+
+    assertEquals(response, adapter.describeNamespace(request));
+    verify(mockDelegate).describeNamespace(request);
+  }
+
+  @Test
+  void testDropNamespace() {
+    DropNamespaceRequest request = new DropNamespaceRequest();
+    request.setId(Arrays.asList("catalog", "database"));
+
+    DropNamespaceResponse response = new DropNamespaceResponse();
+    when(mockDelegate.dropNamespace(request)).thenReturn(response);
+
+    assertEquals(response, adapter.dropNamespace(request));
+    verify(mockDelegate).dropNamespace(request);
+  }
+
+  // Table operations tests
+
+  @Test
+  void testDeclareTableWithValidId() {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(Arrays.asList("catalog", "database", "table"));
+
+    DeclareTableResponse response = new DeclareTableResponse();
+    when(mockDelegate.declareTable(request)).thenReturn(response);
+
+    assertEquals(response, adapter.declareTable(request));
+    verify(mockDelegate).declareTable(request);
+  }
+
+  @Test
+  void testDeclareTableWithTwoLevelIdFails() {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(Arrays.asList("catalog", "database"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.declareTable(request));
+
+    assertTrue(exception.getMessage().contains("exactly 3 levels"));
+    assertTrue(exception.getMessage().contains("2 levels"));
+    verify(mockDelegate, never()).declareTable(any());
+  }
+
+  @Test
+  void testDeclareTableWithFourLevelIdFails() {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(Arrays.asList("catalog", "database", "table", "extra"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.declareTable(request));
+
+    assertTrue(exception.getMessage().contains("exactly 3 levels"));
+    assertTrue(exception.getMessage().contains("4 levels"));
+    verify(mockDelegate, never()).declareTable(any());
+  }
+
+  @Test
+  void testDeclareTableWithNullIdFails() {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(null);
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.declareTable(request));
+
+    assertTrue(exception.getMessage().contains("exactly 3 levels"));
+    verify(mockDelegate, never()).declareTable(any());
+  }
+
+  @Test
+  void testDeclareTableWithEmptyLevelFails() {
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(Arrays.asList("catalog", "", "table"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.declareTable(request));
+
+    assertTrue(exception.getMessage().contains("cannot be null or empty"));
+    verify(mockDelegate, never()).declareTable(any());
+  }
+
+  @Test
+  void testDescribeTable() {
+    DescribeTableRequest request = new DescribeTableRequest();
+    request.setId(Arrays.asList("catalog", "database", "table"));
+
+    DescribeTableResponse response = new DescribeTableResponse();
+    when(mockDelegate.describeTable(request)).thenReturn(response);
+
+    assertEquals(response, adapter.describeTable(request));
+    verify(mockDelegate).describeTable(request);
+  }
+
+  @Test
+  void testDeregisterTable() {
+    DeregisterTableRequest request = new DeregisterTableRequest();
+    request.setId(Arrays.asList("catalog", "database", "table"));
+
+    DeregisterTableResponse response = new DeregisterTableResponse();
+    when(mockDelegate.deregisterTable(request)).thenReturn(response);
+
+    assertEquals(response, adapter.deregisterTable(request));
+    verify(mockDelegate).deregisterTable(request);
+  }
+
+  @Test
+  void testListTables() {
+    ListTablesRequest request = new ListTablesRequest();
+    request.setId(Arrays.asList("catalog", "database"));
+
+    ListTablesResponse response = new ListTablesResponse();
+    when(mockDelegate.listTables(request)).thenReturn(response);
+
+    assertEquals(response, adapter.listTables(request));
+    verify(mockDelegate).listTables(request);
+  }
+
+  @Test
+  void testListTablesWithInvalidIdFails() {
+    ListTablesRequest request = new ListTablesRequest();
+    request.setId(Arrays.asList("catalog", "database", "table"));
+
+    InvalidInputException exception =
+        assertThrows(InvalidInputException.class, () -> adapter.listTables(request));
+
+    assertTrue(exception.getMessage().contains("3 levels"));
+    verify(mockDelegate, never()).listTables(any());
+  }
+}

--- a/python/examples/three_level_adapter_example.py
+++ b/python/examples/three_level_adapter_example.py
@@ -1,0 +1,120 @@
+"""
+Example demonstrating how to use ThreeLevelNamespaceAdapter.
+
+This example shows how to wrap any namespace implementation with the adapter
+to enforce 3-level table identifiers.
+"""
+
+from lance_namespace_impls import ThreeLevelNamespaceAdapter
+from lance_namespace_urllib3_client.models import (
+    DeclareTableRequest,
+    ListNamespacesRequest,
+    CreateNamespaceRequest,
+)
+
+
+def example_with_hive3():
+    """Example: Wrap a Hive3 namespace with 3-level enforcement."""
+    # Uncomment to use with actual Hive3 namespace
+    # from lance_namespace_impls import Hive3Namespace
+    #
+    # # Create underlying Hive3 namespace
+    # hive3 = Hive3Namespace(uri="thrift://localhost:9083")
+    #
+    # # Wrap with 3-level adapter
+    # enforced = ThreeLevelNamespaceAdapter(hive3)
+    #
+    # # Now all table operations require exactly 3 levels
+    # request = DeclareTableRequest(
+    #     id=["catalog", "database", "table"],  # Must be exactly 3 levels
+    #     var_schema=schema
+    # )
+    # enforced.declare_table(request, dataset_bytes)
+    #
+    # # This would fail with ValueError:
+    # # bad_request = DeclareTableRequest(
+    # #     id=["database", "table"],  # Only 2 levels - rejected!
+    # #     var_schema=schema
+    # # )
+    # # enforced.declare_table(bad_request, dataset_bytes)
+    pass
+
+
+def example_with_glue():
+    """Example: Wrap a Glue namespace with 3-level enforcement."""
+    # Uncomment to use with actual Glue namespace
+    # from lance_namespace_impls import GlueNamespace
+    #
+    # # Create underlying Glue namespace
+    # glue = GlueNamespace(region="us-east-1")
+    #
+    # # Wrap with 3-level adapter
+    # enforced = ThreeLevelNamespaceAdapter(glue)
+    #
+    # # Namespace operations allow up to 2 levels
+    # ns_request = ListNamespacesRequest(
+    #     id=["catalog", "database"]  # Up to 2 levels allowed
+    # )
+    # enforced.list_namespaces(ns_request)
+    #
+    # # Create a namespace with 2 levels
+    # create_request = CreateNamespaceRequest(
+    #     id=["catalog", "database"],
+    #     properties={"description": "My database"}
+    # )
+    # enforced.create_namespace(create_request)
+    pass
+
+
+def example_with_polaris():
+    """Example: Wrap a Polaris namespace with 3-level enforcement."""
+    # Uncomment to use with actual Polaris namespace
+    # from lance_namespace_impls import PolarisNamespace
+    #
+    # # Create underlying Polaris namespace (supports unlimited nesting)
+    # polaris = PolarisNamespace(
+    #     endpoint="http://localhost:8181",
+    #     auth_token="your-token"
+    # )
+    #
+    # # Wrap with 3-level adapter to enforce strict hierarchy
+    # enforced = ThreeLevelNamespaceAdapter(polaris)
+    #
+    # # Now Polaris is restricted to 3-level tables
+    # request = DeclareTableRequest(
+    #     id=["catalog", "database", "table"],
+    #     var_schema=schema
+    # )
+    # enforced.declare_table(request, dataset_bytes)
+    #
+    # # This would fail even though Polaris supports it:
+    # # deep_request = DeclareTableRequest(
+    # #     id=["catalog", "db1", "db2", "table"],  # 4 levels - rejected!
+    # #     var_schema=schema
+    # # )
+    # # enforced.declare_table(deep_request, dataset_bytes)
+    pass
+
+
+def main():
+    """Run all examples."""
+    print("ThreeLevelNamespaceAdapter Examples")
+    print("=" * 50)
+    print()
+    print("These examples show how to wrap different namespace")
+    print("implementations with the ThreeLevelNamespaceAdapter.")
+    print()
+    print("Uncomment the code in each example function to try them out.")
+    print()
+    print("Example 1: Hive3 Namespace")
+    example_with_hive3()
+    print()
+    print("Example 2: Glue Namespace")
+    example_with_glue()
+    print()
+    print("Example 3: Polaris Namespace")
+    example_with_polaris()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/lance_namespace_impls/__init__.py
+++ b/python/src/lance_namespace_impls/__init__.py
@@ -12,6 +12,9 @@ This package provides third-party catalog implementations for Lance Namespace:
 - PolarisNamespace: Apache Polaris Catalog
 - UnityNamespace: Unity Catalog
 
+Adapters:
+- ThreeLevelNamespaceAdapter: Enforces exactly 3 levels for tables (catalog.database.table)
+
 Shared infrastructure:
 - RestClient: Reusable HTTP client for REST API implementations
 - RestClientException: Exception raised by RestClient
@@ -24,6 +27,7 @@ from lance_namespace_impls.hive3 import Hive3Namespace
 from lance_namespace_impls.iceberg import IcebergNamespace
 from lance_namespace_impls.polaris import PolarisNamespace
 from lance_namespace_impls.unity import UnityNamespace
+from lance_namespace_impls.three_level_adapter import ThreeLevelNamespaceAdapter
 from lance_namespace_impls.rest_client import (
     RestClient,
     RestClientException,
@@ -43,6 +47,7 @@ __all__ = [
     "IcebergNamespace",
     "PolarisNamespace",
     "UnityNamespace",
+    "ThreeLevelNamespaceAdapter",
     "RestClient",
     "RestClientException",
     "NamespaceException",

--- a/python/src/lance_namespace_impls/three_level_adapter.py
+++ b/python/src/lance_namespace_impls/three_level_adapter.py
@@ -1,0 +1,159 @@
+"""
+Three-level namespace adapter that enforces exactly 3 levels for tables and 2 levels for namespaces.
+
+This adapter wraps any LanceNamespace implementation and validates that:
+- Table identifiers have exactly 3 levels: [catalog, database, table]
+- Namespace identifiers have at most 2 levels: [catalog] or [catalog, database]
+- Operations on non-conforming identifiers are rejected
+
+This is useful for namespace implementations that need to enforce a strict 3-level hierarchy
+(e.g., Unity Catalog, Gravitino) while allowing the underlying implementation to be more flexible.
+
+Example usage:
+    >>> from lance_namespace import connect
+    >>> from lance_namespace_impls.three_level_adapter import ThreeLevelNamespaceAdapter
+    >>>
+    >>> # Wrap any namespace implementation
+    >>> underlying = connect("hive3", {"uri": "thrift://localhost:9083"})
+    >>> enforced = ThreeLevelNamespaceAdapter(underlying)
+    >>>
+    >>> # Now all operations enforce 3-level table identifiers
+    >>> enforced.declare_table(DeclareTableRequest(
+    ...     id=["catalog", "database", "table"],  # Must be exactly 3 levels
+    ...     var_schema=schema
+    ... ), dataset)
+"""
+
+from typing import Optional, List
+
+from lance.namespace import LanceNamespace
+from lance_namespace_urllib3_client.models import (
+    ListNamespacesRequest,
+    ListNamespacesResponse,
+    DescribeNamespaceRequest,
+    DescribeNamespaceResponse,
+    CreateNamespaceRequest,
+    CreateNamespaceResponse,
+    DropNamespaceRequest,
+    DropNamespaceResponse,
+    ListTablesRequest,
+    ListTablesResponse,
+    DeclareTableRequest,
+    DeclareTableResponse,
+    DescribeTableRequest,
+    DescribeTableResponse,
+    DeregisterTableRequest,
+    DeregisterTableResponse,
+)
+
+
+class ThreeLevelNamespaceAdapter(LanceNamespace):
+    """Adapter that enforces exactly 3 levels for table identifiers and 2 levels for namespace identifiers.
+
+    This adapter wraps any LanceNamespace implementation and validates identifier levels
+    before delegating to the underlying implementation.
+    """
+
+    def __init__(self, delegate: LanceNamespace):
+        """Initialize the adapter with an underlying namespace implementation.
+
+        Args:
+            delegate: The underlying LanceNamespace implementation to wrap
+        """
+        self.delegate = delegate
+
+    def namespace_id(self) -> str:
+        """Return a human-readable unique identifier for this namespace instance."""
+        return f"ThreeLevelNamespaceAdapter {{ delegate: {self.delegate.namespace_id()} }}"
+
+    def list_namespaces(self, request: ListNamespacesRequest) -> ListNamespacesResponse:
+        """List namespaces, enforcing at most 2 levels."""
+        self._validate_namespace_id(request.id, "list")
+        return self.delegate.list_namespaces(request)
+
+    def create_namespace(
+        self, request: CreateNamespaceRequest
+    ) -> CreateNamespaceResponse:
+        """Create a namespace, enforcing at most 2 levels."""
+        self._validate_namespace_id(request.id, "create")
+        return self.delegate.create_namespace(request)
+
+    def describe_namespace(
+        self, request: DescribeNamespaceRequest
+    ) -> DescribeNamespaceResponse:
+        """Describe a namespace, enforcing at most 2 levels."""
+        self._validate_namespace_id(request.id, "describe")
+        return self.delegate.describe_namespace(request)
+
+    def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
+        """Drop a namespace, enforcing at most 2 levels."""
+        self._validate_namespace_id(request.id, "drop")
+        return self.delegate.drop_namespace(request)
+
+    def list_tables(self, request: ListTablesRequest) -> ListTablesResponse:
+        """List tables in a namespace, enforcing at most 2 levels for the namespace."""
+        self._validate_namespace_id(request.id, "list tables in")
+        return self.delegate.list_tables(request)
+
+    def declare_table(
+        self, request: DeclareTableRequest, dataset_bytes: bytes
+    ) -> DeclareTableResponse:
+        """Declare a table, enforcing exactly 3 levels."""
+        self._validate_table_id(request.id)
+        return self.delegate.declare_table(request, dataset_bytes)
+
+    def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
+        """Describe a table, enforcing exactly 3 levels."""
+        self._validate_table_id(request.id)
+        return self.delegate.describe_table(request)
+
+    def deregister_table(
+        self, request: DeregisterTableRequest
+    ) -> DeregisterTableResponse:
+        """Deregister a table, enforcing exactly 3 levels."""
+        self._validate_table_id(request.id)
+        return self.delegate.deregister_table(request)
+
+    def _validate_namespace_id(self, id: Optional[List[str]], operation: str) -> None:
+        """Validate that a namespace identifier has at most 2 levels.
+
+        Args:
+            id: The namespace identifier to validate
+            operation: The operation being performed (for error messages)
+
+        Raises:
+            ValueError: If the identifier has more than 2 levels
+        """
+        if id is None:
+            return  # Root namespace is allowed
+
+        levels = len(id)
+        if levels > 2:
+            raise ValueError(
+                f"Cannot {operation} namespace with {levels} levels. "
+                f"Expected at most 2 levels (catalog.database), but got: {'.'.join(id)}"
+            )
+
+    def _validate_table_id(self, id: Optional[List[str]]) -> None:
+        """Validate that a table identifier has exactly 3 levels.
+
+        Args:
+            id: The table identifier to validate
+
+        Raises:
+            ValueError: If the identifier does not have exactly 3 levels
+        """
+        if id is None or len(id) != 3:
+            id_str = ".".join(id) if id else "null"
+            levels = len(id) if id else 0
+            raise ValueError(
+                f"Table identifier must have exactly 3 levels (catalog.database.table), "
+                f"but got {levels} levels: {id_str}"
+            )
+
+        # Validate that no level is null or empty
+        for i, level in enumerate(id):
+            if not level:
+                raise ValueError(
+                    f"Table identifier level {i} cannot be null or empty: {'.'.join(id)}"
+                )

--- a/python/tests/test_three_level_adapter.py
+++ b/python/tests/test_three_level_adapter.py
@@ -1,0 +1,267 @@
+"""Tests for ThreeLevelNamespaceAdapter."""
+
+import pytest
+from unittest.mock import Mock, MagicMock
+
+from lance_namespace_impls.three_level_adapter import ThreeLevelNamespaceAdapter
+from lance_namespace_urllib3_client.models import (
+    ListNamespacesRequest,
+    ListNamespacesResponse,
+    DescribeNamespaceRequest,
+    DescribeNamespaceResponse,
+    CreateNamespaceRequest,
+    CreateNamespaceResponse,
+    DropNamespaceRequest,
+    DropNamespaceResponse,
+    ListTablesRequest,
+    ListTablesResponse,
+    DeclareTableRequest,
+    DeclareTableResponse,
+    DescribeTableRequest,
+    DescribeTableResponse,
+    DeregisterTableRequest,
+    DeregisterTableResponse,
+)
+
+
+@pytest.fixture
+def mock_delegate():
+    """Create a mock delegate namespace."""
+    return Mock()
+
+
+@pytest.fixture
+def adapter(mock_delegate):
+    """Create a ThreeLevelNamespaceAdapter with a mock delegate."""
+    return ThreeLevelNamespaceAdapter(mock_delegate)
+
+
+class TestNamespaceId:
+    """Tests for namespace_id method."""
+
+    def test_namespace_id_includes_delegate(self, adapter, mock_delegate):
+        mock_delegate.namespace_id.return_value = "MockNamespace"
+        result = adapter.namespace_id()
+        assert "ThreeLevelNamespaceAdapter" in result
+        assert "MockNamespace" in result
+
+
+class TestListNamespaces:
+    """Tests for list_namespaces method."""
+
+    def test_list_namespaces_with_root_id(self, adapter, mock_delegate):
+        request = ListNamespacesRequest(id=None)
+        response = ListNamespacesResponse(namespaces=[])
+        mock_delegate.list_namespaces.return_value = response
+
+        result = adapter.list_namespaces(request)
+
+        assert result == response
+        mock_delegate.list_namespaces.assert_called_once_with(request)
+
+    def test_list_namespaces_with_one_level(self, adapter, mock_delegate):
+        request = ListNamespacesRequest(id=["catalog"])
+        response = ListNamespacesResponse(namespaces=[])
+        mock_delegate.list_namespaces.return_value = response
+
+        result = adapter.list_namespaces(request)
+
+        assert result == response
+        mock_delegate.list_namespaces.assert_called_once_with(request)
+
+    def test_list_namespaces_with_two_levels(self, adapter, mock_delegate):
+        request = ListNamespacesRequest(id=["catalog", "database"])
+        response = ListNamespacesResponse(namespaces=[])
+        mock_delegate.list_namespaces.return_value = response
+
+        result = adapter.list_namespaces(request)
+
+        assert result == response
+        mock_delegate.list_namespaces.assert_called_once_with(request)
+
+    def test_list_namespaces_with_three_levels_fails(self, adapter, mock_delegate):
+        request = ListNamespacesRequest(id=["catalog", "database", "table"])
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.list_namespaces(request)
+
+        assert "3 levels" in str(exc_info.value)
+        assert "at most 2 levels" in str(exc_info.value)
+        mock_delegate.list_namespaces.assert_not_called()
+
+
+class TestCreateNamespace:
+    """Tests for create_namespace method."""
+
+    def test_create_namespace_with_valid_id(self, adapter, mock_delegate):
+        request = CreateNamespaceRequest(id=["catalog", "database"])
+        response = CreateNamespaceResponse()
+        mock_delegate.create_namespace.return_value = response
+
+        result = adapter.create_namespace(request)
+
+        assert result == response
+        mock_delegate.create_namespace.assert_called_once_with(request)
+
+    def test_create_namespace_with_invalid_id_fails(self, adapter, mock_delegate):
+        request = CreateNamespaceRequest(id=["catalog", "database", "extra"])
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.create_namespace(request)
+
+        assert "3 levels" in str(exc_info.value)
+        mock_delegate.create_namespace.assert_not_called()
+
+
+class TestDescribeNamespace:
+    """Tests for describe_namespace method."""
+
+    def test_describe_namespace(self, adapter, mock_delegate):
+        request = DescribeNamespaceRequest(id=["catalog"])
+        response = DescribeNamespaceResponse(properties={})
+        mock_delegate.describe_namespace.return_value = response
+
+        result = adapter.describe_namespace(request)
+
+        assert result == response
+        mock_delegate.describe_namespace.assert_called_once_with(request)
+
+
+class TestDropNamespace:
+    """Tests for drop_namespace method."""
+
+    def test_drop_namespace(self, adapter, mock_delegate):
+        request = DropNamespaceRequest(id=["catalog", "database"])
+        response = DropNamespaceResponse()
+        mock_delegate.drop_namespace.return_value = response
+
+        result = adapter.drop_namespace(request)
+
+        assert result == response
+        mock_delegate.drop_namespace.assert_called_once_with(request)
+
+
+class TestListTables:
+    """Tests for list_tables method."""
+
+    def test_list_tables_with_valid_id(self, adapter, mock_delegate):
+        request = ListTablesRequest(id=["catalog", "database"])
+        response = ListTablesResponse(tables=[])
+        mock_delegate.list_tables.return_value = response
+
+        result = adapter.list_tables(request)
+
+        assert result == response
+        mock_delegate.list_tables.assert_called_once_with(request)
+
+    def test_list_tables_with_invalid_id_fails(self, adapter, mock_delegate):
+        request = ListTablesRequest(id=["catalog", "database", "table"])
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.list_tables(request)
+
+        assert "3 levels" in str(exc_info.value)
+        mock_delegate.list_tables.assert_not_called()
+
+
+class TestDeclareTable:
+    """Tests for declare_table method."""
+
+    def test_declare_table_with_valid_id(self, adapter, mock_delegate):
+        request = DeclareTableRequest(id=["catalog", "database", "table"])
+        dataset_bytes = b"mock_dataset"
+        response = DeclareTableResponse()
+        mock_delegate.declare_table.return_value = response
+
+        result = adapter.declare_table(request, dataset_bytes)
+
+        assert result == response
+        mock_delegate.declare_table.assert_called_once_with(request, dataset_bytes)
+
+    def test_declare_table_with_two_levels_fails(self, adapter, mock_delegate):
+        request = DeclareTableRequest(id=["catalog", "database"])
+        dataset_bytes = b"mock_dataset"
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.declare_table(request, dataset_bytes)
+
+        assert "exactly 3 levels" in str(exc_info.value)
+        assert "2 levels" in str(exc_info.value)
+        mock_delegate.declare_table.assert_not_called()
+
+    def test_declare_table_with_four_levels_fails(self, adapter, mock_delegate):
+        request = DeclareTableRequest(id=["catalog", "database", "table", "extra"])
+        dataset_bytes = b"mock_dataset"
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.declare_table(request, dataset_bytes)
+
+        assert "exactly 3 levels" in str(exc_info.value)
+        assert "4 levels" in str(exc_info.value)
+        mock_delegate.declare_table.assert_not_called()
+
+    def test_declare_table_with_null_id_fails(self, adapter, mock_delegate):
+        request = DeclareTableRequest(id=None)
+        dataset_bytes = b"mock_dataset"
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.declare_table(request, dataset_bytes)
+
+        assert "exactly 3 levels" in str(exc_info.value)
+        mock_delegate.declare_table.assert_not_called()
+
+    def test_declare_table_with_empty_level_fails(self, adapter, mock_delegate):
+        request = DeclareTableRequest(id=["catalog", "", "table"])
+        dataset_bytes = b"mock_dataset"
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.declare_table(request, dataset_bytes)
+
+        assert "cannot be null or empty" in str(exc_info.value)
+        mock_delegate.declare_table.assert_not_called()
+
+
+class TestDescribeTable:
+    """Tests for describe_table method."""
+
+    def test_describe_table(self, adapter, mock_delegate):
+        request = DescribeTableRequest(id=["catalog", "database", "table"])
+        response = DescribeTableResponse()
+        mock_delegate.describe_table.return_value = response
+
+        result = adapter.describe_table(request)
+
+        assert result == response
+        mock_delegate.describe_table.assert_called_once_with(request)
+
+    def test_describe_table_with_invalid_id_fails(self, adapter, mock_delegate):
+        request = DescribeTableRequest(id=["catalog", "database"])
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.describe_table(request)
+
+        assert "exactly 3 levels" in str(exc_info.value)
+        mock_delegate.describe_table.assert_not_called()
+
+
+class TestDeregisterTable:
+    """Tests for deregister_table method."""
+
+    def test_deregister_table(self, adapter, mock_delegate):
+        request = DeregisterTableRequest(id=["catalog", "database", "table"])
+        response = DeregisterTableResponse()
+        mock_delegate.deregister_table.return_value = response
+
+        result = adapter.deregister_table(request)
+
+        assert result == response
+        mock_delegate.deregister_table.assert_called_once_with(request)
+
+    def test_deregister_table_with_invalid_id_fails(self, adapter, mock_delegate):
+        request = DeregisterTableRequest(id=["catalog", "database"])
+
+        with pytest.raises(ValueError) as exc_info:
+            adapter.deregister_table(request)
+
+        assert "exactly 3 levels" in str(exc_info.value)
+        mock_delegate.deregister_table.assert_not_called()


### PR DESCRIPTION
This commit introduces a reusable adapter that enforces exactly 3 levels for table identifiers (catalog.database.table) and at most 2 levels for namespace identifiers (catalog or catalog.database).

Key features:
- Wraps any LanceNamespace implementation using the Decorator pattern
- Validates identifier levels before delegating operations
- Provides clear error messages for invalid identifiers
- Available in both Java and Python

Java implementation:
- ThreeLevelNamespaceAdapter class in lance-namespace-impls-core
- Comprehensive test suite with 19 test cases (all passing)
- Throws InvalidInputException for invalid identifiers

Python implementation:
- ThreeLevelNamespaceAdapter class exported from lance_namespace_impls
- Comprehensive test suite using pytest
- Raises ValueError for invalid identifiers
- Includes usage examples

Benefits:
- Separation of concerns: level enforcement separated from core logic
- Reusability: any namespace implementation can be wrapped
- Consistency: all implementations get the same validation behavior
- Maintainability: validation logic centralized in one place

This addresses the need for strict 3-level enforcement in catalogs like Unity Catalog and Gravitino without duplicating validation logic across implementations.