### PR TITLE
chore: update lance-core dependency to v4.0.0-beta.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.0.0-beta.7</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.0.0-beta.7`.
- Keep the change scoped to the dependency version bump only.

## Verification
- Ran `cd java && make lint` (pass).
- Ran `cd java && make build`.
- `make build` initially failed because `org.lance:lance-core:4.0.0-beta.7` was not available from Maven Central on this runner.
- Installed the tagged source artifact locally for verification using:
  - `git clone https://github.com/lance-format/lance.git`
  - `git checkout v4.0.0-beta.7`
  - `cd java && mvn -DskipTests -Dskip.build.jni=true install`
- Re-ran `cd java && make build` (pass).

## Triggering tag
- refs/tags/v4.0.0-beta.7
