### PR TITLE
chore: update lance-core dependency to v4.0.0-beta.8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.0.0-beta.8</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.0.0-beta.8`
- Keep the dependency coordinate as `org.lance:lance-core`

## Verification
- Ran `cd java && make lint` (passes)
- Ran `cd java && make build` (passes)

## Triggering tag
- refs/tags/v4.0.0-beta.8
- https://github.com/lance-format/lance/tree/v4.0.0-beta.8
