### PR TITLE
chore: update lance-core dependency to v4.0.0-beta.13

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.0.0-beta.13</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.0.0-beta.13`

## Verification
- ran `cd java && make lint` (passes)
- ran `cd java && make build` (passes)
- note: `org.lance:lance-core:4.0.0-beta.13` was not available from Maven Central in this runner, so I installed it locally from `lance-format/lance` tag `v4.0.0-beta.13` before rerunning `make build`

## Triggering Tag
- `refs/tags/v4.0.0-beta.13`
