### PR TITLE
chore: update lance-core dependency to v4.1.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.1.0-beta.2</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.1.0-beta.2`.
- Keep dependency coordinates as `org.lance:lance-core`.

## Verification
- Ran `cd java && make lint` successfully.
- Ran `cd java && make build` successfully.
  - `lance-core:4.1.0-beta.2` was not yet available on Maven Central during this run, so the artifact was installed locally from the upstream tag before running the build.

## Triggering Tag
- refs/tags/v4.1.0-beta.2
