### PR TITLE
chore: update lance-core dependency to v4.1.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>4.1.0-beta.3</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `4.1.0-beta.3`.
- This aligns the Java namespace implementations with the requested Lance prerelease dependency.

## Verification
- Ran `cd java && make lint` successfully.
- Ran `cd java && make build` successfully.
- Note: `org.lance:lance-core:4.1.0-beta.3` was not yet resolvable from Maven Central at run time, so I installed `lance-core` from tag source locally on the runner to complete build verification.

## Triggering tag
- refs/tags/v4.1.0-beta.3
