### PR TITLE
feat: support connecting Python Hive3 Namespace to a Kerberos-secured Hive Metastore

### DIFF
--- a/docs/src/hive3.md
+++ b/docs/src/hive3.md
@@ -14,6 +14,22 @@ The **client.pool-size** property is optional and specifies the size of the HMS 
 
 The **root** property is optional and specifies the storage root location of the lakehouse on Hive catalog. Default value is the current working directory.
 
+The **hive.metastore.sasl.enabled** property is optional. When set to `true`, the Python Hive3 implementation uses Kerberos SASL to connect to Hive Metastore instead of a plain Thrift transport.
+
+The **hive.metastore.kerberos.principal** property is optional and may be used to derive the Kerberos service name from the metastore service principal, such as `hive-metastore/_HOST@EXAMPLE.COM`.
+
+The **kerberos.service-name** property is optional and overrides the Kerberos service name used for SASL negotiation.
+
+The **kerberos.client-principal** property is optional and specifies the Kerberos client principal to use during SASL negotiation. If omitted, the default local Kerberos credentials are used.
+
+## Authentication
+
+For Kerberos-secured Hive Metastore deployments with `hive.metastore.sasl.enabled=true`, clients must have valid Kerberos credentials available before opening the namespace connection.
+
+For the Python implementation, enabling `hive.metastore.sasl.enabled=true` switches the metastore wrapper to a Kerberos SASL transport.
+
+For the Java implementation, Kerberos-related Hive Metastore settings are typically provided through the Hadoop `Configuration` used to initialize the namespace.
+
 ## Object Mapping
 
 ### Namespace

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,6 +29,8 @@ hive2 = [
 hive3 = [
     "thrift>=0.13.0",
     "hive-metastore-client>=1.0.0",
+    "pure-sasl>=0.6.2",
+    "kerberos>=1.3.1",
 ]
 iceberg = []
 polaris = []
@@ -38,6 +40,8 @@ all = [
     "botocore>=1.35.0",
     "thrift>=0.13.0",
     "hive-metastore-client>=1.0.0",
+    "pure-sasl>=0.6.2",
+    "kerberos>=1.3.1",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/python/src/lance_namespace_impls/hive3.py
+++ b/python/src/lance_namespace_impls/hive3.py
@@ -31,6 +31,8 @@ Configuration Properties:
     client.pool-size (int): Size of the HMS client connection pool (default: 3)
 """
 
+from io import BytesIO
+import struct
 from typing import List, Optional
 from urllib.parse import urlparse
 import os
@@ -38,6 +40,16 @@ import logging
 
 try:
     from hive_metastore_client import HiveMetastoreClient as Client
+    from thrift.protocol import TBinaryProtocol
+    from thrift.transport import TSocket
+    from thrift.transport.TTransport import (
+        CReadableTransport,
+        TTransportBase,
+        TTransportException,
+    )
+    from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (
+        Client as ThriftClient,
+    )
     from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (
         Database as HiveDatabase,
         Table as HiveTable,
@@ -54,6 +66,33 @@ try:
 except ImportError:
     HIVE_AVAILABLE = False
     Client = None
+    TBinaryProtocol = None
+    TSocket = None
+
+    class CReadableTransport:
+        pass
+
+    class TTransportBase:
+        pass
+
+    class TTransportException(Exception):
+        """Fallback thrift transport exception used when thrift is unavailable."""
+
+        UNKNOWN = 0
+        NOT_OPEN = 1
+        ALREADY_OPEN = 2
+        TIMED_OUT = 3
+        END_OF_FILE = 4
+
+        def __init__(self, type=UNKNOWN, message=None):
+            self.type = type
+            self.message = message
+            super().__init__(message)
+
+    class ThriftClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
     HiveDatabase = None
     HiveTable = None
     StorageDescriptor = None
@@ -63,6 +102,16 @@ except ImportError:
     AlreadyExistsException = None
     InvalidOperationException = None
     MetaException = None
+
+try:
+    from puresasl.client import SASLClient
+    import puresasl.mechanisms as sasl_mechanisms
+
+    SASL_SUPPORT_AVAILABLE = True
+except ImportError:
+    SASLClient = None
+    sasl_mechanisms = None
+    SASL_SUPPORT_AVAILABLE = False
 
 from lance.namespace import LanceNamespace
 from lance_namespace_urllib3_client.models import (
@@ -96,12 +145,268 @@ MANAGED_BY_KEY = "managed_by"
 VERSION_KEY = "version"
 EXTERNAL_TABLE = "EXTERNAL_TABLE"
 DEFAULT_CATALOG = "hive"
+HIVE_METASTORE_SASL_ENABLED_KEY = "hive.metastore.sasl.enabled"
+_SASL_NEGOTIATION_HEADER = struct.Struct(">BI")
+_SASL_FRAME_HEADER = struct.Struct(">I")
+
+
+def _as_bool(value) -> bool:
+    """Parse a configuration value into a boolean."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _get_kerberos_service_name(properties: dict) -> str:
+    """Resolve the Kerberos service name used for SASL negotiation."""
+    explicit_service_name = properties.get("kerberos.service-name")
+    if explicit_service_name:
+        return explicit_service_name
+
+    metastore_principal = properties.get("hive.metastore.kerberos.principal")
+    if metastore_principal and "/" in metastore_principal:
+        return metastore_principal.split("/", 1)[0]
+
+    return "hive"
+
+
+class _KerberosSaslTransport(TTransportBase, CReadableTransport):
+    """Minimal SASL transport for Kerberos-authenticated HMS connections."""
+
+    START = 1
+    OK = 2
+    BAD = 3
+    ERROR = 4
+    COMPLETE = 5
+
+    def __init__(
+        self,
+        transport,
+        host: str,
+        service: str,
+        principal: Optional[str] = None,
+    ):
+        self._transport = transport
+        self._host = host
+        self._service = service
+        self._principal = principal
+        self._sasl = None
+        self._encoding_enabled = False
+        self._wbuf = BytesIO()
+        self._rbuf = BytesIO(b"")
+
+    def isOpen(self):
+        return self._transport.isOpen()
+
+    def is_open(self):
+        return self.isOpen()
+
+    def _create_sasl_client(self):
+        if not SASL_SUPPORT_AVAILABLE or not getattr(
+            sasl_mechanisms, "have_kerberos", False
+        ):
+            raise ImportError(
+                "Kerberos SASL support requires the 'pure-sasl' and 'kerberos' "
+                "packages. Please install with: "
+                "pip install 'lance-namespace-impls[hive3]'"
+            )
+
+        return SASLClient(
+            self._host,
+            service=self._service,
+            mechanism="GSSAPI",
+            principal=self._principal,
+        )
+
+    def open(self):
+        if not self.isOpen():
+            self._transport.open()
+
+        if self._sasl is not None:
+            raise TTransportException(
+                type=TTransportException.ALREADY_OPEN,
+                message="SASL transport is already open",
+            )
+
+        self._sasl = self._create_sasl_client()
+
+        try:
+            self._send_sasl_message(self.START, self._sasl.mechanism.encode("ascii"))
+            initial_response = self._sasl.process()
+            self._send_sasl_message(self.OK, initial_response or b"")
+
+            while True:
+                status, payload = self._recv_sasl_message()
+                if status in (self.BAD, self.ERROR):
+                    error = payload.decode("utf-8", errors="replace") or str(status)
+                    raise TTransportException(
+                        type=TTransportException.NOT_OPEN,
+                        message=f"SASL negotiation failed: {error}",
+                    )
+
+                if status not in (self.OK, self.COMPLETE):
+                    raise TTransportException(
+                        type=TTransportException.NOT_OPEN,
+                        message=f"Unexpected SASL negotiation status: {status}",
+                    )
+
+                if status == self.COMPLETE:
+                    # Hive Metastore finishes the SASL negotiation here. In
+                    # practice, feeding the COMPLETE payload back into the
+                    # Python GSSAPI client causes an invalid-token failure
+                    # against real Kerberized HMS deployments.
+                    break
+
+                response = self._sasl.process(payload or b"")
+                self._send_sasl_message(self.OK, response or b"")
+            self._encoding_enabled = self._requires_sasl_encoding()
+        except Exception:
+            self.close()
+            raise
+
+    def close(self):
+        try:
+            if self._sasl is not None:
+                try:
+                    self._sasl.dispose()
+                except Exception:
+                    pass
+        finally:
+            self._sasl = None
+            self._encoding_enabled = False
+            self._wbuf = BytesIO()
+            self._rbuf = BytesIO(b"")
+            self._transport.close()
+
+    def read(self, sz):
+        result = self._rbuf.read(sz)
+        if len(result) == sz:
+            return result
+
+        self._read_frame()
+        return result + self._rbuf.read(sz - len(result))
+
+    def write(self, buf):
+        self._wbuf.write(buf)
+
+    def flush(self):
+        payload = self._wbuf.getvalue()
+        self._wbuf = BytesIO()
+
+        if not payload:
+            self._transport.flush()
+            return
+
+        self._transport.write(self._encode_frame(payload))
+        self._transport.flush()
+
+    def _send_sasl_message(self, status: int, body: bytes):
+        payload = body or b""
+        header = _SASL_NEGOTIATION_HEADER.pack(status, len(payload))
+        self._transport.write(header + payload)
+        self._transport.flush()
+
+    def _recv_sasl_message(self):
+        header = self._read_all_from_transport(5)
+        status, length = _SASL_NEGOTIATION_HEADER.unpack(header)
+        payload = self._read_all_from_transport(length) if length else b""
+        return status, payload
+
+    def _encode_frame(self, payload: bytes) -> bytes:
+        encoded = self._sasl.wrap(payload) if self._encoding_enabled else payload
+        return _SASL_FRAME_HEADER.pack(len(encoded)) + encoded
+
+    def _read_frame(self):
+        header = self._read_all_from_transport(4)
+        (length,) = _SASL_FRAME_HEADER.unpack(header)
+        payload = self._read_all_from_transport(length) if length else b""
+        self._rbuf = BytesIO(self._decode_frame(payload))
+
+    def _decode_frame(self, payload: bytes) -> bytes:
+        if self._encoding_enabled:
+            return self._sasl.unwrap(payload)
+        return payload
+
+    def _requires_sasl_encoding(self) -> bool:
+        qop = getattr(self._sasl, "qop", "auth")
+        if isinstance(qop, bytes):
+            qop = qop.decode("ascii", errors="ignore")
+        return str(qop).lower() not in {"", "auth"}
+
+    def _read_all_from_transport(self, size: int) -> bytes:
+        try:
+            return self._transport.readAll(size)
+        except EOFError as exc:
+            raise TTransportException(
+                type=TTransportException.END_OF_FILE,
+                message="End of file reading from transport",
+            ) from exc
+
+    @property
+    def cstringio_buf(self):
+        return self._rbuf
+
+    def cstringio_refill(self, partialread, reqlen):
+        prefix = partialread
+        while len(prefix) < reqlen:
+            self._read_frame()
+            prefix += self._rbuf.getvalue()
+        self._rbuf = BytesIO(prefix)
+        return self._rbuf
+
+
+class _KerberosHiveMetastoreClient(ThriftClient):
+    """Thrift HMS client backed by a Kerberos SASL transport."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        kerberos_service_name: str,
+        kerberos_client_principal: Optional[str] = None,
+    ) -> None:
+        protocol = self._init_protocol(
+            host, port, kerberos_service_name, kerberos_client_principal
+        )
+        super().__init__(protocol)
+
+    @staticmethod
+    def _init_protocol(
+        host: str,
+        port: int,
+        kerberos_service_name: str,
+        kerberos_client_principal: Optional[str],
+    ):
+        transport = _KerberosSaslTransport(
+            TSocket.TSocket(host, int(port)),
+            host=host,
+            service=kerberos_service_name,
+            principal=kerberos_client_principal,
+        )
+        return TBinaryProtocol.TBinaryProtocol(transport)
+
+    def open(self) -> "_KerberosHiveMetastoreClient":
+        self._oprot.trans.open()
+        return self
+
+    def close(self) -> None:
+        self._oprot.trans.close()
 
 
 class Hive3MetastoreClientWrapper:
     """Helper class to manage Hive 3.x Metastore client connections."""
 
-    def __init__(self, uri: str, ugi: Optional[str] = None):
+    def __init__(
+        self,
+        uri: str,
+        ugi: Optional[str] = None,
+        *,
+        sasl_enabled: bool = False,
+        kerberos_service_name: str = "hive",
+        kerberos_client_principal: Optional[str] = None,
+    ):
         if not HIVE_AVAILABLE:
             raise ImportError(
                 "Hive dependencies not installed. Please install with: "
@@ -110,6 +415,9 @@ class Hive3MetastoreClientWrapper:
 
         self._uri = uri
         self._ugi = ugi.split(":") if ugi else None
+        self._sasl_enabled = sasl_enabled
+        self._kerberos_service_name = kerberos_service_name
+        self._kerberos_client_principal = kerberos_client_principal
         url_parts = urlparse(self._uri)
         self._host = url_parts.hostname or "localhost"
         self._port = url_parts.port or 9083
@@ -117,7 +425,15 @@ class Hive3MetastoreClientWrapper:
 
     def __enter__(self):
         """Enter context manager."""
-        self._client = Client(host=self._host, port=self._port)
+        if self._sasl_enabled:
+            self._client = _KerberosHiveMetastoreClient(
+                host=self._host,
+                port=self._port,
+                kerberos_service_name=self._kerberos_service_name,
+                kerberos_client_principal=self._kerberos_client_principal,
+            )
+        else:
+            self._client = Client(host=self._host, port=self._port)
         self._client.open()
         if self._ugi:
             self._client.set_ugi(*self._ugi)
@@ -162,6 +478,12 @@ class Hive3Namespace(LanceNamespace):
         self.ugi = properties.get("ugi")
         self.root = properties.get("root", os.getcwd())
         self.pool_size = int(properties.get("client.pool-size", "3"))
+        self.sasl_enabled = _as_bool(properties.get(HIVE_METASTORE_SASL_ENABLED_KEY))
+        self.metastore_kerberos_principal = properties.get(
+            "hive.metastore.kerberos.principal"
+        )
+        self.kerberos_service_name = _get_kerberos_service_name(properties)
+        self.kerberos_client_principal = properties.get("kerberos.client-principal")
 
         self._properties = properties.copy()
         self._client = None
@@ -174,7 +496,13 @@ class Hive3Namespace(LanceNamespace):
     def client(self):
         """Get the Hive client, initializing it if necessary."""
         if self._client is None:
-            self._client = Hive3MetastoreClientWrapper(self.uri, self.ugi)
+            self._client = Hive3MetastoreClientWrapper(
+                self.uri,
+                self.ugi,
+                sasl_enabled=self.sasl_enabled,
+                kerberos_service_name=self.kerberos_service_name,
+                kerberos_client_principal=self.kerberos_client_principal,
+            )
         return self._client
 
     def _normalize_identifier(self, identifier: List[str]) -> tuple:
@@ -257,6 +585,17 @@ class Hive3Namespace(LanceNamespace):
                 }
                 if self.ugi:
                     properties["ugi"] = self.ugi
+                if self.sasl_enabled:
+                    properties[HIVE_METASTORE_SASL_ENABLED_KEY] = "true"
+                    if self.metastore_kerberos_principal:
+                        properties["hive.metastore.kerberos.principal"] = (
+                            self.metastore_kerberos_principal
+                        )
+                    properties["kerberos.service-name"] = self.kerberos_service_name
+                if self.kerberos_client_principal:
+                    properties["kerberos.client-principal"] = (
+                        self.kerberos_client_principal
+                    )
                 return DescribeNamespaceResponse(properties=properties)
 
             if len(request.id) == 1:

--- a/python/tests/test_hive3.py
+++ b/python/tests/test_hive3.py
@@ -2,10 +2,19 @@
 Tests for Lance Hive3 Namespace implementation.
 """
 
+import builtins
+import importlib.util
+from pathlib import Path
+import struct
 import pytest
 from unittest.mock import MagicMock, patch
 
-from lance_namespace_impls.hive3 import Hive3Namespace
+from lance_namespace_impls.hive3 import (
+    Hive3MetastoreClientWrapper,
+    Hive3Namespace,
+    _KerberosSaslTransport,
+    _get_kerberos_service_name,
+)
 from lance_namespace_urllib3_client.models import (
     ListNamespacesRequest,
     DescribeNamespaceRequest,
@@ -38,6 +47,72 @@ def hive_namespace(mock_hive_client):
         return namespace
 
 
+class FakeTransport:
+    """Minimal in-memory transport for SASL transport tests."""
+
+    def __init__(self, reads: bytes = b""):
+        self._reads = bytearray(reads)
+        self.writes = []
+        self.opened = False
+        self.flush_count = 0
+        self.closed = False
+
+    def isOpen(self):
+        return self.opened
+
+    def open(self):
+        self.opened = True
+
+    def close(self):
+        self.closed = True
+        self.opened = False
+
+    def write(self, data):
+        self.writes.append(data)
+
+    def flush(self):
+        self.flush_count += 1
+
+    def readAll(self, size):
+        if len(self._reads) < size:
+            raise EOFError("not enough bytes")
+        data = bytes(self._reads[:size])
+        del self._reads[:size]
+        return data
+
+
+class FakeSaslClient:
+    """Small controllable SASL client test double."""
+
+    mechanism = "GSSAPI"
+
+    def __init__(self, *, qop="auth", process_responses=None):
+        self.qop = qop
+        self._process_responses = list(process_responses or [])
+        self.process_calls = []
+        self.wrap_calls = []
+        self.unwrap_calls = []
+        self.disposed = False
+
+    def process(self, payload=None):
+        self.process_calls.append(payload)
+        if self._process_responses:
+            return self._process_responses.pop(0)
+        return b""
+
+    def wrap(self, payload):
+        self.wrap_calls.append(payload)
+        return b"wrapped:" + payload
+
+    def unwrap(self, payload):
+        self.unwrap_calls.append(payload)
+        assert payload.startswith(b"wrapped:")
+        return payload[len(b"wrapped:") :]
+
+    def dispose(self):
+        self.disposed = True
+
+
 class TestHive3Namespace:
     """Test cases for Hive3Namespace."""
 
@@ -61,14 +136,125 @@ class TestHive3Namespace:
 
                 _ = namespace.client
                 mock_client.assert_called_once_with(
-                    "thrift://localhost:9083", "user:group1,group2"
+                    "thrift://localhost:9083",
+                    "user:group1,group2",
+                    sasl_enabled=False,
+                    kerberos_service_name="hive",
+                    kerberos_client_principal=None,
                 )
+
+    def test_initialization_with_kerberos_sasl(self):
+        """Test namespace initialization with Kerberos SASL enabled."""
+        with patch("lance_namespace_impls.hive3.HIVE_AVAILABLE", True):
+            with patch(
+                "lance_namespace_impls.hive3.Hive3MetastoreClientWrapper"
+            ) as mock_client:
+                namespace = Hive3Namespace(
+                    uri="thrift://metastore.example.com:9083",
+                    root="/tmp/warehouse",
+                    **{
+                        "hive.metastore.sasl.enabled": "true",
+                        "hive.metastore.kerberos.principal": (
+                            "hive-metastore/_HOST@EXAMPLE.COM"
+                        ),
+                        "kerberos.client-principal": "alice@EXAMPLE.COM",
+                    },
+                )
+
+                assert namespace.sasl_enabled is True
+                assert (
+                    namespace.metastore_kerberos_principal
+                    == "hive-metastore/_HOST@EXAMPLE.COM"
+                )
+                assert namespace.kerberos_service_name == "hive-metastore"
+                assert namespace.kerberos_client_principal == "alice@EXAMPLE.COM"
+
+                _ = namespace.client
+                mock_client.assert_called_once_with(
+                    "thrift://metastore.example.com:9083",
+                    None,
+                    sasl_enabled=True,
+                    kerberos_service_name="hive-metastore",
+                    kerberos_client_principal="alice@EXAMPLE.COM",
+                )
+
+    def test_describe_root_namespace_preserves_kerberos_properties(self):
+        """Test root namespace description returns the configured Kerberos settings."""
+        with patch("lance_namespace_impls.hive3.HIVE_AVAILABLE", True):
+            namespace = Hive3Namespace(
+                uri="thrift://metastore.example.com:9083",
+                root="/tmp/warehouse",
+                **{
+                    "hive.metastore.sasl.enabled": "true",
+                    "hive.metastore.kerberos.principal": (
+                        "hive-metastore/_HOST@EXAMPLE.COM"
+                    ),
+                    "kerberos.client-principal": "alice@EXAMPLE.COM",
+                },
+            )
+
+        response = namespace.describe_namespace(DescribeNamespaceRequest(id=[]))
+        assert response.properties["hive.metastore.sasl.enabled"] == "true"
+        assert (
+            response.properties["hive.metastore.kerberos.principal"]
+            == "hive-metastore/_HOST@EXAMPLE.COM"
+        )
+        assert response.properties["kerberos.service-name"] == "hive-metastore"
+        assert (
+            response.properties["kerberos.client-principal"]
+            == "alice@EXAMPLE.COM"
+        )
+
+    def test_explicit_kerberos_service_name_override(self):
+        """Test that an explicit service name wins over principal-derived values."""
+        properties = {
+            "kerberos.service-name": "custom-service",
+            "hive.metastore.kerberos.principal": "hive-metastore/_HOST@EXAMPLE.COM",
+        }
+
+        assert _get_kerberos_service_name(properties) == "custom-service"
 
     def test_initialization_without_hive_deps(self):
         """Test that initialization fails gracefully without Hive dependencies."""
         with patch("lance_namespace_impls.hive3.HIVE_AVAILABLE", False):
             with pytest.raises(ImportError, match="Hive dependencies not installed"):
                 Hive3Namespace(uri="thrift://localhost:9083")
+
+    def test_module_imports_without_hive_dependencies(self):
+        """Test that the module still imports when Hive dependencies are missing."""
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "lance_namespace_impls"
+            / "hive3.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "isolated_hive3_without_hive_deps", module_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        real_import = builtins.__import__
+
+        blocked_imports = (
+            "hive_metastore_client",
+            "thrift.protocol",
+            "thrift.transport",
+            "thrift.transport.TTransport",
+            "thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore",
+            "thrift_files.libraries.thrift_hive_metastore_client.ttypes",
+        )
+
+        def import_without_hive(name, globals=None, locals=None, fromlist=(), level=0):
+            if name in blocked_imports:
+                raise ImportError(f"blocked import: {name}")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=import_without_hive):
+            assert spec.loader is not None
+            spec.loader.exec_module(module)
+
+        assert module.HIVE_AVAILABLE is False
+        assert issubclass(module._KerberosSaslTransport, module.TTransportBase)
+        assert issubclass(module._KerberosSaslTransport, module.CReadableTransport)
 
     def test_list_namespaces_root(self, hive_namespace, mock_hive_client):
         """Test listing catalogs at root level."""
@@ -322,5 +508,184 @@ class TestHive3Namespace:
                     client = restored.client
                     assert client is not None
                     mock_client.assert_called_once_with(
-                        "thrift://localhost:9083", "user:group1,group2"
+                        "thrift://localhost:9083",
+                        "user:group1,group2",
+                        sasl_enabled=False,
+                        kerberos_service_name="hive",
+                        kerberos_client_principal=None,
                     )
+
+
+class TestHive3MetastoreClientWrapper:
+    """Tests for transport selection in the Hive3 client wrapper."""
+
+    def test_uses_plain_client_when_sasl_disabled(self):
+        """Test that non-SASL connections keep using the plain HMS client."""
+        with patch("lance_namespace_impls.hive3.HIVE_AVAILABLE", True):
+            with patch("lance_namespace_impls.hive3.Client") as mock_client_class:
+                mock_client = MagicMock()
+                mock_client_class.return_value = mock_client
+
+                wrapper = Hive3MetastoreClientWrapper(
+                    "thrift://localhost:9083", "user:group1,group2"
+                )
+
+                with wrapper as client:
+                    assert client is mock_client
+
+                mock_client_class.assert_called_once_with(host="localhost", port=9083)
+                mock_client.open.assert_called_once()
+                mock_client.set_ugi.assert_called_once_with("user", "group1,group2")
+                mock_client.close.assert_called_once()
+
+    def test_uses_kerberos_client_when_sasl_enabled(self):
+        """Test that SASL-enabled connections use the Kerberos transport."""
+        with patch("lance_namespace_impls.hive3.HIVE_AVAILABLE", True):
+            with patch(
+                "lance_namespace_impls.hive3._KerberosHiveMetastoreClient"
+            ) as mock_client_class:
+                mock_client = MagicMock()
+                mock_client_class.return_value = mock_client
+
+                wrapper = Hive3MetastoreClientWrapper(
+                    "thrift://localhost:9083",
+                    sasl_enabled=True,
+                    kerberos_service_name="hive-metastore",
+                    kerberos_client_principal="alice@EXAMPLE.COM",
+                )
+
+                with wrapper as client:
+                    assert client is mock_client
+
+                mock_client_class.assert_called_once_with(
+                    host="localhost",
+                    port=9083,
+                    kerberos_service_name="hive-metastore",
+                    kerberos_client_principal="alice@EXAMPLE.COM",
+                )
+                mock_client.open.assert_called_once()
+                mock_client.close.assert_called_once()
+
+
+class TestKerberosSaslTransport:
+    """Tests for Kerberos SASL transport framing and negotiation."""
+
+    def test_flush_uses_plain_framing_for_auth_qop(self):
+        """Test that auth-only QOP keeps the payload unwrapped but framed."""
+        raw_transport = FakeTransport()
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+        transport._sasl = FakeSaslClient(qop="auth")
+        transport._encoding_enabled = False
+
+        transport.write(b"ping")
+        transport.flush()
+
+        assert raw_transport.writes == [struct.pack(">I", 4) + b"ping"]
+        assert transport._sasl.wrap_calls == []
+
+    def test_flush_frames_wrapped_payload_for_protected_qop(self):
+        """Test that protected QOP writes a length-prefixed wrapped payload."""
+        raw_transport = FakeTransport()
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+        transport._sasl = FakeSaslClient(qop="auth-conf")
+        transport._encoding_enabled = True
+
+        transport.write(b"ping")
+        transport.flush()
+
+        wrapped = b"wrapped:ping"
+        assert raw_transport.writes == [struct.pack(">I", len(wrapped)) + wrapped]
+        assert transport._sasl.wrap_calls == [b"ping"]
+
+    def test_read_frame_unwraps_payload_without_frame_header(self):
+        """Test that unwrap receives only the framed payload bytes."""
+        wrapped = b"wrapped:pong"
+        raw_transport = FakeTransport(struct.pack(">I", len(wrapped)) + wrapped)
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+        transport._sasl = FakeSaslClient(qop="auth-conf")
+        transport._encoding_enabled = True
+
+        transport._read_frame()
+
+        assert transport.read(4) == b"pong"
+        assert transport._sasl.unwrap_calls == [wrapped]
+
+    def test_open_negotiates_and_detects_protected_qop(self):
+        """Test SASL negotiation and QOP detection during open."""
+        server_messages = b"".join(
+            [
+                struct.pack(">BI", 2, len(b"challenge")) + b"challenge",
+                struct.pack(">BI", 5, len(b"final")) + b"final",
+            ]
+        )
+        raw_transport = FakeTransport(server_messages)
+        sasl_client = FakeSaslClient(
+            qop="auth-conf",
+            process_responses=[b"initial", b"response"],
+        )
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+
+        with patch.object(transport, "_create_sasl_client", return_value=sasl_client):
+            transport.open()
+
+        assert raw_transport.opened is True
+        assert transport._encoding_enabled is True
+        assert sasl_client.process_calls == [None, b"challenge"]
+        assert raw_transport.writes == [
+            struct.pack(">BI", 1, len(b"GSSAPI")) + b"GSSAPI",
+            struct.pack(">BI", 2, len(b"initial")) + b"initial",
+            struct.pack(">BI", 2, len(b"response")) + b"response",
+        ]
+
+    def test_open_ignores_complete_payload(self):
+        """Test that COMPLETE ends negotiation without another SASL step."""
+        server_messages = b"".join(
+            [
+                struct.pack(">BI", 2, len(b"challenge")) + b"challenge",
+                struct.pack(">BI", 5, len(b"final")) + b"final",
+            ]
+        )
+        raw_transport = FakeTransport(server_messages)
+        sasl_client = FakeSaslClient(
+            qop="auth",
+            process_responses=[b"initial", b"response"],
+        )
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+
+        with patch.object(transport, "_create_sasl_client", return_value=sasl_client):
+            transport.open()
+
+        assert sasl_client.process_calls == [None, b"challenge"]
+
+    def test_open_passes_empty_ok_payload_as_empty_bytes(self):
+        """Test that an empty OK payload is normalized to empty bytes."""
+        server_messages = b"".join(
+            [
+                struct.pack(">BI", 2, len(b"challenge")) + b"challenge",
+                struct.pack(">BI", 2, 0),
+                struct.pack(">BI", 5, 0),
+            ]
+        )
+        raw_transport = FakeTransport(server_messages)
+        sasl_client = FakeSaslClient(
+            qop="auth",
+            process_responses=[b"initial", b"response", b""],
+        )
+        transport = _KerberosSaslTransport(
+            raw_transport, host="metastore.example.com", service="hive"
+        )
+
+        with patch.object(transport, "_create_sasl_client", return_value=sasl_client):
+            transport.open()
+
+        assert sasl_client.process_calls == [None, b"challenge", b""]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -199,6 +199,12 @@ wheels = [
 ]
 
 [[package]]
+name = "kerberos"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/cd/f98699a6e806b9d974ea1d3376b91f09edcb90415adbf31e3b56ee99ba64/kerberos-1.3.1.tar.gz", hash = "sha256:cdd046142a4e0060f96a00eb13d82a5d9ebc0f2d7934393ed559bac773460a2c", size = 19126, upload-time = "2021-01-09T06:43:46.862Z" }
+
+[[package]]
 name = "lance-namespace"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -212,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
@@ -226,6 +232,8 @@ all = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "hive-metastore-client" },
+    { name = "kerberos" },
+    { name = "pure-sasl" },
     { name = "thrift" },
 ]
 dev = [
@@ -243,6 +251,8 @@ hive2 = [
 ]
 hive3 = [
     { name = "hive-metastore-client" },
+    { name = "kerberos" },
+    { name = "pure-sasl" },
     { name = "thrift" },
 ]
 
@@ -255,7 +265,11 @@ requires-dist = [
     { name = "hive-metastore-client", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "hive-metastore-client", marker = "extra == 'hive2'", specifier = ">=1.0.0" },
     { name = "hive-metastore-client", marker = "extra == 'hive3'", specifier = ">=1.0.0" },
+    { name = "kerberos", marker = "extra == 'all'", specifier = ">=1.3.1" },
+    { name = "kerberos", marker = "extra == 'hive3'", specifier = ">=1.3.1" },
     { name = "lance-namespace-urllib3-client", specifier = ">=0.4.2" },
+    { name = "pure-sasl", marker = "extra == 'all'", specifier = ">=0.6.2" },
+    { name = "pure-sasl", marker = "extra == 'hive3'", specifier = ">=0.6.2" },
     { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "pylance", specifier = ">=0.26.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -447,6 +461,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
+
+[[package]]
+name = "pure-sasl"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/b7/a0d688f86c869073cc28c0640899394a1cf68a6d87ee78a09565e9037da6/pure-sasl-0.6.2.tar.gz", hash = "sha256:53c1355f5da95e2b85b2cc9a6af435518edc20c81193faa0eea65fdc835138f4", size = 11617, upload-time = "2019-10-14T21:43:57.13Z" }
 
 [[package]]
 name = "pyarrow"


### PR DESCRIPTION
## Background

The current Python `Hive3Namespace` implementation only supports plain Thrift connections to Hive Metastore and cannot connect to Kerberized HMS deployments with `hive.metastore.sasl.enabled=true`.

## Changes

This PR adds Kerberos SASL support to the Python `Hive3Namespace` implementation while keeping the existing non-secure behavior unchanged.

Main changes include:

- add Kerberos SASL support to the Python Hive3 metastore wrapper
- use a Kerberos SASL transport when `hive.metastore.sasl.enabled=true`
- keep the existing plain Thrift path when SASL is not enabled
- support the following optional properties:
  - `hive.metastore.kerberos.principal`
  - `kerberos.service-name`
  - `kerberos.client-principal`
- add the required Python `hive3` dependencies
- add/update corresponding unit tests
- update the Hive3 documentation

## Configuration behavior

- `hive.metastore.sasl.enabled` is disabled by default
- `kerberos.service-name` takes precedence when explicitly configured
- otherwise it may be derived from `hive.metastore.kerberos.principal`
- `kerberos.client-principal` is optional; if omitted, local default Kerberos credentials are used

## Impact

This change enables the Python Hive3 Namespace to work with Kerberized Hive Metastore deployments without affecting existing non-SASL users.

## Testing

This PR includes test updates covering:

- default plain client behavior
- Kerberos configuration parsing
- Kerberos client selection when SASL is enabled
- plain client selection when SASL is disabled

## Notes

This change is scoped to Kerberos SASL support for the Python Hive3 Namespace only. It does not modify the Java Hive3 implementation and does not introduce a Kerberos integration test environment in this iteration.

---

Assisted by ChatGPT