### PR TITLE
chore: update lance-core dependency to v5.0.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.0.0-beta.1</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `5.0.0-beta.1`.

## Verification
- Ran `cd java && make lint` successfully.
- Ran `cd java && make build` successfully.

## Notes
- `org.lance:lance-core:5.0.0-beta.1` was not yet available from Maven Central in this runner environment, so I built and installed it locally from `lance-format/lance` at tag `refs/tags/v5.0.0-beta.1` to complete verification.

Triggering tag: `refs/tags/v5.0.0-beta.1`
