### PR TITLE
chore: update lance-core dependency to v5.0.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.0.0-beta.2</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core` in `java/pom.xml` from `2.0.0` to `5.0.0-beta.2`.
- Keep all other dependency versions and project configuration unchanged.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed.
  - Note: `org.lance:lance-core:5.0.0-beta.2` was not available from Maven Central during this run, so `lance-core` was installed locally from the upstream Lance tag before re-running `make build`.

## Upstream Tag
- Triggering tag: [`refs/tags/v5.0.0-beta.2`](https://github.com/lance-format/lance/releases/tag/v5.0.0-beta.2)
