### PR TITLE
chore: update lance-core dependency to v5.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` to `5.0.0-beta.4`.
- Keep project configuration unchanged aside from the dependency version bump.

## Verification
- Ran `cd java && make lint` successfully.
- Ran `cd java && make build` successfully after installing `org.lance:lance-core:5.0.0-beta.4` from source locally for resolution in this runner environment.

## Triggering tag
- refs/tags/v5.0.0-beta.4
