### PR TITLE
chore: update lance-core dependency to v5.0.0-beta.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.0.0-beta.6</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core` in `java/pom.xml` from `2.0.0` to `5.0.0-beta.6`.

## Verification
- Ran `cd java && make lint` successfully.
- Ran `cd java && make build` successfully after resolving `lance-core:5.0.0-beta.6` from upstream source tag into local Maven cache for this runner.

## Triggering tag
- refs/tags/v5.0.0-beta.6
