### PR TITLE
chore: update lance-core dependency to v5.0.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.0.0-rc.1</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core` in `java/pom.xml` to `5.0.0-rc.1`.
- Keep the dependency bump isolated to the `lance-core.version` property.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed.

## Triggering Tag
- refs/tags/v5.0.0-rc.1
