### PR TITLE
chore: update lance-core dependency to v5.1.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.1.0-beta.2</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `5.1.0-beta.2`.
- Keep all other dependency and module configuration unchanged.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after resolving availability of `org.lance:lance-core:5.1.0-beta.2` by installing from source tag into the local Maven cache on this runner.

## Triggering Tag
- `refs/tags/v5.1.0-beta.2`
