### PR TITLE
chore: update lance-core dependency to v5.1.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>5.1.0-beta.3</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `5.1.0-beta.3`
- verify formatting/lint with `cd java && make lint`
- verify build with `cd java && make build`

## Notes
- `org.lance:lance-core:5.1.0-beta.3` was not yet resolvable from Maven Central in this runner, so I built and installed it locally from `lance-format/lance` tag `v5.1.0-beta.3` to complete build verification.

## Triggering Tag
- https://github.com/lance-format/lance/releases/tag/v5.1.0-beta.3
- refs/tags/v5.1.0-beta.3
