### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.1</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `6.0.0-beta.1`.
- This bumps the Java modules to consume the latest beta release.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed.

## Related
- Triggering tag: `refs/tags/v6.0.0-beta.1`
