### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.2</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `6.0.0-beta.2`.
- Keep dependency coordinates unchanged (`org.lance:lance-core`).

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed.
- Note: `org.lance:lance-core:6.0.0-beta.2` was not available from Maven Central during this run, so I built and installed `lance-core` locally from the upstream `v6.0.0-beta.2` source tag to complete compatibility verification.

## Triggering tag
- `refs/tags/v6.0.0-beta.2`
