### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.3</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `6.0.0-beta.3`.
- Triggering tag: refs/tags/v6.0.0-beta.3

## Verification
- `cd java && make lint` passed.
- `cd /tmp/lance-v6.0.0-beta.3/java && ./mvnw install -DskipTests -Dskip.build.jni` passed to install the tagged `org.lance:lance-core:6.0.0-beta.3` artifact locally because Maven Central did not yet resolve that version during verification.
- `cd java && make build` passed after the local tagged artifact install.
