### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` from `2.0.0` to `6.0.0-beta.4` in `java/pom.xml`.
- Triggered by Lance tag [refs/tags/v6.0.0-beta.4](https://github.com/lance-format/lance/tree/refs/tags/v6.0.0-beta.4).

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:6.0.0-beta.4` was not yet listed in Maven Central metadata on this runner, so I checked out `lance-format/lance` at `refs/tags/v6.0.0-beta.4` and installed the matching `lance-core` artifact into the local Maven cache before rerunning `make build`.
