### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `6.0.0-beta.4`.
- Link to the triggering tag: refs/tags/v6.0.0-beta.4.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:6.0.0-beta.4` locally from the upstream `lance-format/lance` `refs/tags/v6.0.0-beta.4` tag because Maven Central metadata did not yet include `6.0.0-beta.4` at verification time.
