### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.4</lance-core.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
## Summary
- Bump the Java `lance-core.version` property to `6.0.0-beta.4`.
- Verify the dependency update with Java lint and build checks.

## Verification
- `cd java && make lint`
- `cd java && make build`

Triggered by tag: `refs/tags/v6.0.0-beta.4`
