### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.5</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `6.0.0-beta.5` in `java/pom.xml`.
- Link triggering tag: refs/tags/v6.0.0-beta.5

## Verification
- `cd java && make lint` passed.
- `cd /tmp/lance-source-v6.0.0-beta.5/java && ./mvnw install -DskipTests -Dskip.build.jni=true` passed to install the tagged `lance-core` artifact locally because `6.0.0-beta.5` was not yet available from Maven Central during verification.
- `cd java && make build` passed after installing the tagged artifact locally.
