### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.6</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bump `lance-core.version` from `2.0.0` to `6.0.0-beta.6` in `java/pom.xml`.
- Link triggering Lance tag: https://github.com/lance-format/lance/tree/refs/tags/v6.0.0-beta.6

## Verification

- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:6.0.0-beta.6` from Maven Central because the release tag had just been published and the artifact was not indexed there yet.
- Installed `org.lance:lance-core:6.0.0-beta.6` locally from `lance-format/lance@refs/tags/v6.0.0-beta.6`, then reran `cd java && make build`; it passed.
