### PR TITLE
chore: update lance-core dependency to v6.0.0-beta.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-beta.7</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` from `2.0.0` to `6.0.0-beta.7` in `java/pom.xml`.
- This bump is for the triggering tag `refs/tags/v6.0.0-beta.7`.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:6.0.0-beta.7` from the tagged `lance-format/lance` source into the local Maven cache, because Maven Central metadata did not yet list `6.0.0-beta.7` at verification time.
