### PR TITLE
chore: update lance-core dependency to v6.0.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-rc.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update the Java `lance-core` dependency to `6.0.0-rc.1`.
- Verified lint with `cd java && make lint`.
- Verified build with `cd java && make build` after installing the tagged `lance-core` artifact locally because it is not yet available from Maven Central on this runner.

Triggering tag: `refs/tags/v6.0.0-rc.1`
