### PR TITLE
chore: update lance-core dependency to v6.0.0-rc.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>6.0.0-rc.2</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bump `lance-core.version` from `2.0.0` to `6.0.0-rc.2` in `java/pom.xml`.
- Verified formatting with `cd java && make lint`.
- Verified the Java build with `cd java && make build` after installing `org.lance:lance-core:6.0.0-rc.2` locally from the triggering Lance tag, because the artifact is not yet available in Maven Central metadata.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v6.0.0-rc.2
