### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.2</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` from `2.0.0` to `7.0.0-beta.2` in `java/pom.xml`.
- Uses the semver dependency version from the triggering tag [`refs/tags/v7.0.0-beta.2`](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.2).

## Verification
- `cd java && make lint`
- `cd /tmp/lance/java && ./mvnw install -DskipTests -Dskip.build.jni=true` to install `org.lance:lance-core:7.0.0-beta.2` locally from the matching Lance tag because Maven Central did not yet have the artifact.
- `cd java && make build`
