### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.3</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `7.0.0-beta.3` in `java/pom.xml`.
- Verified Java lint and build with the updated dependency.
- Triggering tag: [refs/tags/v7.0.0-beta.3](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.3)

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:7.0.0-beta.3` was not yet listed in Maven Central metadata on this runner, so I checked out `lance-format/lance` at `refs/tags/v7.0.0-beta.3` and installed the tagged `lance-core` artifact locally before rerunning `make build`.
