### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.4</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` to `7.0.0-beta.4`.
- Triggering tag: refs/tags/v7.0.0-beta.4

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: Maven Central did not yet list `org.lance:lance-core:7.0.0-beta.4` during verification, so I installed the tagged `lance-format/lance` Java artifact locally from `refs/tags/v7.0.0-beta.4` before rerunning `make build`.
