### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.5</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Updates `lance-core.version` from `2.0.0` to `7.0.0-beta.5` in `java/pom.xml`.
- Triggered by Lance tag [`refs/tags/v7.0.0-beta.5`](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.5).

## Verification

- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:7.0.0-beta.5` from Maven Central because the upstream Java publish was still in progress.
- Checked out `lance-format/lance` at `refs/tags/v7.0.0-beta.5`, installed `lance-core` locally with `./mvnw install -DskipTests -Dskip.build.jni=true`, then reran `cd java && make build` successfully.
