### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.6</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump the Java `lance-core.version` property from `2.0.0` to `7.0.0-beta.6`.
- Link the triggering Lance tag: refs/tags/v7.0.0-beta.6

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:7.0.0-beta.6` from Maven Central because Central metadata has not listed beta.6 yet.
- Checked out `lance-format/lance` at `v7.0.0-beta.6` and installed the tagged `lance-core` artifact locally with `cd /tmp/lance-v7.0.0-beta.6/java && ./mvnw install -DskipTests -Dskip.build.jni=true`.
- Reran `cd java && make build`; it passed against the locally installed `7.0.0-beta.6` artifact.
