### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.7</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.0.0-beta.7`.
- Triggering tag: refs/tags/v7.0.0-beta.7

## Verification
- `cd java && make lint` passed.
- `cd java && make build` was attempted, but Maven could not resolve `org.lance:lance-core:7.0.0-beta.7` from Maven Central. The upstream `lance-format/lance` release exists for `v7.0.0-beta.7`, and its "Build and publish Java packages" workflow was still in progress when checked.
