### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.8</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.0.0-beta.8`.
- Triggering Lance tag: `refs/tags/v7.0.0-beta.8`.

## Verification

- `cd java && make lint` passed.
- `cd java && make build` was run, but Maven could not resolve `org.lance:lance-core:jar:7.0.0-beta.8` from Maven Central yet. The upstream Lance release tag exists, but Maven Central metadata still lists `7.0.0-beta.7` as latest at the time this PR was created.
