### PR TITLE
docs: simplify catalog integration page titles

### DIFF
--- a/docs/src/glue.md
+++ b/docs/src/glue.md
@@ -1,4 +1,4 @@
-# AWS Glue Data Catalog Lance Namespace Implementation Spec
+# AWS Glue Data Catalog
 
 This document describes how the AWS Glue Data Catalog
 implements the Lance Namespace client spec.

--- a/docs/src/hive2.md
+++ b/docs/src/hive2.md
@@ -1,4 +1,4 @@
-# Apache Hive 2.X MetaStore Lance Namespace Implementation Spec
+# Apache Hive 2.X MetaStore
 
 This document describes how the Hive 2.x MetaStore implements the Lance Namespace client spec.
 

--- a/docs/src/hive3.md
+++ b/docs/src/hive3.md
@@ -1,4 +1,4 @@
-# Apache Hive 3+.X MetaStore Lance Namespace Implementation Spec
+# Apache Hive 3+.X MetaStore
 
 This document describes how the Hive 3.x MetaStore implements the Lance Namespace client spec.
 

--- a/docs/src/iceberg.md
+++ b/docs/src/iceberg.md
@@ -1,4 +1,4 @@
-#  Apache Iceberg REST Catalog Lance Namespace Implementation Spec
+# Apache Iceberg REST Catalog
 
 This document describes how the Apache Iceberg REST Catalog implements the Lance Namespace client spec.
 

--- a/docs/src/polaris.md
+++ b/docs/src/polaris.md
@@ -1,4 +1,4 @@
-# Apache Polaris Lance Namespace Implementation Spec
+# Apache Polaris
 
 This document describes how the Polaris Catalog implements the Lance Namespace client spec.
 

--- a/docs/src/unity.md
+++ b/docs/src/unity.md
@@ -1,4 +1,4 @@
-# Unity Catalog Lance Namespace Implementation Spec
+# Unity Catalog
 
 This document describes how the Unity Catalog implements the Lance Namespace client spec.
 


### PR DESCRIPTION
## Summary

- Remove the verbose "Lance Namespace Implementation Spec" suffix from all catalog integration page titles
- Titles now use just the catalog name (e.g. "Apache Polaris" instead of "Apache Polaris Lance Namespace Implementation Spec")