### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.9

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.9</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bumps `lance-core.version` in `java/pom.xml` to `7.0.0-beta.9`.
- Triggering tag: [`refs/tags/v7.0.0-beta.9`](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.9)

## Verification

- `cd java && make lint`
- Installed `org.lance:lance-core:7.0.0-beta.9` locally from `lance-format/lance` at `refs/tags/v7.0.0-beta.9` because Maven Central metadata did not yet list the artifact.
- `cd java && make build`
