### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.10

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.10</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` to `7.0.0-beta.10`.
- Triggering tag: `refs/tags/v7.0.0-beta.10` (https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.10).

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially failed because `org.lance:lance-core:7.0.0-beta.10` was not yet available from Maven Central metadata.
- Checked out `lance-format/lance` at `refs/tags/v7.0.0-beta.10`, installed the matching Java `lance-core` artifact locally with `./mvnw install -DskipTests -Dskip.build.jni=true`, then reran `cd java && make build` successfully.
