### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.11

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.11</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update the Java `lance-core.version` property to `7.0.0-beta.11`.
- This dependency bump corresponds to the triggering tag `refs/tags/v7.0.0-beta.11`.

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:7.0.0-beta.11` was not yet available from Maven Central during verification, so I checked out `lance-format/lance` at `refs/tags/v7.0.0-beta.11`, installed the matching `lance-core` artifact into the local Maven cache, and reran the build successfully.
