### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.12

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.12</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.0.0-beta.12`.
- Triggering tag: refs/tags/v7.0.0-beta.12

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially failed because `org.lance:lance-core:7.0.0-beta.12` was not yet available from Maven Central.
- Verified the tag exists in `lance-format/lance`, checked out `refs/tags/v7.0.0-beta.12`, installed the exact tagged `org.lance:lance-core:7.0.0-beta.12` artifact into the local Maven cache, then reran `cd java && make build` successfully.
