### PR TITLE
chore: update lance-core dependency to v7.0.0-beta.13

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-beta.13</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bump `lance-core.version` from `2.0.0` to `7.0.0-beta.13` in `java/pom.xml`.
- Triggering tag: [refs/tags/v7.0.0-beta.13](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.13)

## Verification

- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:7.0.0-beta.13` was not present in Maven Central metadata during verification, so the Lance repo tag `v7.0.0-beta.13` was checked out and installed to the local Maven cache before rerunning `make build`.
