### PR TITLE
chore: update lance-core dependency to v7.0.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.0.0-rc.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Update `lance-core.version` from `2.0.0` to `7.0.0-rc.1`.
- Triggering tag: `refs/tags/v7.0.0-rc.1`.

## Verification

- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:7.0.0-rc.1` locally from the `lance-format/lance` `refs/tags/v7.0.0-rc.1` source, because the RC artifact was not yet resolvable from Maven Central during the initial build attempt.
