### PR TITLE
chore: update lance-core dependency to v7.1.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.1.0-beta.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.1.0-beta.1`.
- Triggering tag: [refs/tags/v7.1.0-beta.1](https://github.com/lance-format/lance/releases/tag/v7.1.0-beta.1)

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially failed because `org.lance:lance-core:7.1.0-beta.1` was not yet available from Maven Central.
- Checked out `lance-format/lance` at `refs/tags/v7.1.0-beta.1` and installed the Java artifact locally with `./mvnw install -DskipTests -Dskip.build.jni=true`.
- Re-ran `cd java && make build`; it passed successfully.
