### PR TITLE
chore: update lance-core dependency to v7.1.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.1.0-beta.2</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update the Java `lance-core.version` property to `7.1.0-beta.2`.
- Verified lint and build for the Java modules.
- Triggering tag: refs/tags/v7.1.0-beta.2

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:7.1.0-beta.2` was not yet present in public Maven Central metadata during verification, so I installed the matching Java artifact locally from the `lance-format/lance` `refs/tags/v7.1.0-beta.2` source tag before rerunning `make build`.
