### PR TITLE
chore: update lance-core dependency to v7.1.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.1.0-beta.3</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update the Java `lance-core` dependency from `2.0.0` to `7.1.0-beta.3`.
- Triggering tag: `refs/tags/v7.1.0-beta.3`

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing the tagged `org.lance:lance-core:7.1.0-beta.3` artifact from `lance-format/lance` locally, because Maven Central did not yet list `7.1.0-beta.3` during verification.
