### PR TITLE
chore: update lance-core dependency to v7.1.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.1.0-beta.4</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.1.0-beta.4`.
- Use semver format matching the triggering tag `refs/tags/v7.1.0-beta.4`.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:7.1.0-beta.4` locally from the `lance-format/lance` tag because the artifact is not yet available in Maven Central.
