### PR TITLE
chore: update lance-core dependency to v7.1.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.1.0-rc.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `7.1.0-rc.1`.
- Verified lint with `cd java && make lint`.
- Verified build with `cd java && make build` after locally installing the tagged `lance-core` artifact because `7.1.0-rc.1` is not yet available from Maven Central.

Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.1.0-rc.1 (`refs/tags/v7.1.0-rc.1`)
