### PR TITLE
chore: update lance-core dependency to v7.2.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.2.0-beta.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.2.0-beta.1`.
- Keeps the dependency version in semver format for the Lance beta release.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.2.0-beta.1 (`refs/tags/v7.2.0-beta.1`)

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:7.2.0-beta.1` from the tagged `lance-format/lance` source into the local Maven cache, because the artifact was not yet available from Maven Central during this run.
