### PR TITLE
chore: update lance-core dependency to v7.2.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.2.0-beta.2</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` from `2.0.0` to `7.2.0-beta.2` in `java/pom.xml`.
- This dependency bump was triggered by tag [`refs/tags/v7.2.0-beta.2`](https://github.com/lance-format/lance/releases/tag/v7.2.0-beta.2).

## Verification
- `cd java && make lint`
- `cd java && make build`
