### PR TITLE
chore: update lance-core dependency to v7.2.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.2.0-beta.3</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` to `7.2.0-beta.3`.
- Keep the dependency version in semver format for the Lance release tag.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially failed because `org.lance:lance-core:7.2.0-beta.3` is not yet listed in Maven Central metadata.
- Installed the tagged Lance Java artifact locally from `lance-format/lance` at `refs/tags/v7.2.0-beta.3` with `cd /tmp/lance/java && ./mvnw install -DskipTests -Dskip.build.jni=true`.
- Reran `cd java && make build`; it passed with the locally installed `7.2.0-beta.3` artifact.

Triggering tag: `refs/tags/v7.2.0-beta.3`
