### PR TITLE
chore: update lance-core dependency to v7.2.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.2.0-beta.4</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `7.2.0-beta.4`.
- Triggering tag: [refs/tags/v7.2.0-beta.4](https://github.com/lance-format/lance/releases/tag/v7.2.0-beta.4)

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:7.2.0-beta.4` locally from the `lance-format/lance` `v7.2.0-beta.4` tag because Maven Central metadata did not yet list `7.2.0-beta.4` at verification time.
