### PR TITLE
chore: update lance-core dependency to v7.2.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>7.2.0-beta.5</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Updates the Java `lance-core.version` property from `2.0.0` to `7.2.0-beta.5`.
- Links this dependency bump to the triggering Lance tag: refs/tags/v7.2.0-beta.5.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:7.2.0-beta.5` from Maven Central because the artifact is not published there yet.
- Checked out `lance-format/lance` at `refs/tags/v7.2.0-beta.5`, installed the tagged Java `lance-core` artifact into the local Maven repository, then reran `cd java && make build` successfully.
