### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `8.0.0-beta.1`.
- Triggering tag: [refs/tags/v8.0.0-beta.1](https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.1)

## Verification

- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:8.0.0-beta.1` from Maven Central, so the `lance-format/lance` `v8.0.0-beta.1` tag was checked out and `cd /tmp/lance/java && ./mvnw install -DskipTests -Dskip.build.jni=true` was run to install the tagged artifact locally.
- `cd java && make build` then passed against the locally installed `lance-core:8.0.0-beta.1` artifact.
