### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.2</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` from `2.0.0` to `8.0.0-beta.2` in `java/pom.xml`.
- Keeps the update scoped to the Lance dependency property.

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:8.0.0-beta.2` was not listed in Maven Central metadata during verification, so I checked out `lance-format/lance` at the triggering tag and installed the tagged Java artifact locally before rerunning `make build`.

Triggering tag: [`refs/tags/v8.0.0-beta.2`](https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.2)
