### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.3</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `8.0.0-beta.3` in `java/pom.xml`.
- Verified Java lint and build against Lance `8.0.0-beta.3`.

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:8.0.0-beta.3` was not yet listed in Maven Central metadata during verification, so the tagged Lance source was built and installed locally from `lance-format/lance` tag `refs/tags/v8.0.0-beta.3` before rerunning `make build`.

Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v8.0.0-beta.3
