### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.4</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `8.0.0-beta.4`.
- Triggering Lance tag: `refs/tags/v8.0.0-beta.4`.

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed.

Note: `org.lance:lance-core:8.0.0-beta.4` was not available from Maven Central on this runner, so I checked out `lance-format/lance` at `refs/tags/v8.0.0-beta.4`, installed the matching Java artifact into the local Maven cache, and then reran the lint/build checks successfully.
