### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.5</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` from `2.0.0` to `8.0.0-beta.5`.
- Link triggering tag: refs/tags/v8.0.0-beta.5

## Verification
- `cd java && make lint` passed.
- `cd java && make build` was run, but Maven could not resolve `org.lance:lance-core:8.0.0-beta.5` from Maven Central. Current Maven Central metadata lists `8.0.0-beta.1` through `8.0.0-beta.4`, but not `8.0.0-beta.5`; the `8.0.0-beta.5` POM URL returns 404. This appears to be an upstream artifact publication/propagation issue for the tag rather than a source compatibility error in this repository.
