### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.6</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` in `java/pom.xml` to `8.0.0-beta.6`.
- Verified the Java modules against the beta.6 Lance artifact from the triggering tag.

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:8.0.0-beta.6` was not yet available from Maven Central during verification, so I checked out `lance-format/lance` at `refs/tags/v8.0.0-beta.6` and installed the Java artifact locally before rerunning `make build`.

Triggering tag: `refs/tags/v8.0.0-beta.6`
