### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.7</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` in `java/pom.xml` from `2.0.0` to `8.0.0-beta.7`.
- Triggering tag: [`refs/tags/v8.0.0-beta.7`](https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.7)

## Verification
- `cd java && make lint` passed.
- `cd /tmp/lance/java && ./mvnw install -DskipTests -Dskip.build.jni` passed for the `v8.0.0-beta.7` tag because the artifact is not yet present in Maven Central.
- `cd java && make build` passed after installing the tagged Lance artifact locally.
