### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.8</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps the Java `lance-core.version` property from `2.0.0` to `8.0.0-beta.8`.
- Triggering Lance tag: https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.8 (`refs/tags/v8.0.0-beta.8`).

## Verification
- `cd java && make lint` passed.
- `cd java && make build` passed after installing `org.lance:lance-core:8.0.0-beta.8` locally from the `lance-format/lance` `v8.0.0-beta.8` tag, because the artifact is not yet available on Maven Central.
