### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.13

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.13</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bumps `lance-core.version` from `2.0.0` to `8.0.0-beta.13` in `java/pom.xml`.
- Triggering tag: [`refs/tags/v8.0.0-beta.13`](https://github.com/lance-format/lance/tree/refs/tags/v8.0.0-beta.13).

## Verification

- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:8.0.0-beta.13` from Maven Central because the artifact metadata did not list beta.13 yet.
- Installed `org.lance:lance-core:8.0.0-beta.13` locally from the `lance-format/lance` tag with `./mvnw install -DskipTests -Dskip.build.jni=true`, then reran `cd java && make build` successfully.
