### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.14

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.14</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `8.0.0-beta.14` in `java/pom.xml`.
- Triggering tag: `refs/tags/v8.0.0-beta.14`

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially failed because `org.lance:lance-core:8.0.0-beta.14` was not available from Maven Central on this runner.
- Checked out `lance-format/lance` at `refs/tags/v8.0.0-beta.14`, ran `./mvnw install -DskipTests -Dskip.build.jni=true` from its `java` directory, then reran `cd java && make build`; build passed.
