### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.15

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.15</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Updates `lance-core.version` from `2.0.0` to `8.0.0-beta.15` in `java/pom.xml`.
- Verified Java lint and build for the dependency bump.
- Triggering tag: refs/tags/v8.0.0-beta.15

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:8.0.0-beta.15` was not yet available from Maven Central on this runner, so I installed the artifact locally from the `lance-format/lance` `refs/tags/v8.0.0-beta.15` source tag before rerunning `make build`.
