### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.17

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.17</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update the Java `lance-core.version` property to `8.0.0-beta.17`.
- This dependency bump was triggered by `refs/tags/v8.0.0-beta.17`.

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:8.0.0-beta.17` was not yet available from Maven Central during verification, so I checked out `lance-format/lance` at `refs/tags/v8.0.0-beta.17`, installed the Java artifact locally, and reran the build successfully.
