### PR TITLE
chore: update lance-core dependency to v8.0.0-beta.19

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-beta.19</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary

- Bumps `lance-core.version` in `java/pom.xml` to `8.0.0-beta.19`.
- Triggered by Lance tag [`refs/tags/v8.0.0-beta.19`](https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.19).

## Verification

- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:8.0.0-beta.19` from Maven Central in this runner.
- Installed `org.lance:lance-core:8.0.0-beta.19` locally from the matching `lance-format/lance` tag with `cd /tmp/lance-v8.0.0-beta.19/java && ./mvnw install -DskipTests -Dskip.build.jni -Dspotless.skip=true`, then reran `cd java && make build`; it passed.
