### PR TITLE
fix(glue): implement namespaceExists with GetDatabase

### DIFF
--- a/java/lance-namespace-glue/src/main/java/org/lance/namespace/glue/GlueNamespace.java
+++ b/java/lance-namespace-glue/src/main/java/org/lance/namespace/glue/GlueNamespace.java
@@ -38,6 +38,7 @@ import org.lance.namespace.model.ListNamespacesRequest;
 import org.lance.namespace.model.ListNamespacesResponse;
 import org.lance.namespace.model.ListTablesRequest;
 import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.namespace.model.TableExistsRequest;
 import org.lance.namespace.util.LanceTableUtil;
 
@@ -146,6 +147,15 @@ public class GlueNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
+  public void namespaceExists(NamespaceExistsRequest request) {
+    String namespaceName = namespaceFromId(request.getId());
+    if (!databaseExists(namespaceName)) {
+      throw new NamespaceNotFoundException(
+          "Namespace not found: " + namespaceName, "NAMESPACE_NOT_FOUND", namespaceName);
+    }
+  }
+
+  @Override
   public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
     String namespaceName = namespaceFromId(request.getId());
 
@@ -233,7 +243,7 @@ public class GlueNamespace implements LanceNamespace, Closeable {
       } while (glueNextToken != null && remaining > 0);
       return new ListTablesResponse().tables(tables).pageToken(glueNextToken);
     } catch (EntityNotFoundException e) {
-      throw GlueToLanceErrorConverter.notFound(e, "Glue database not found: %s", namespaceName);
+      throw GlueToLanceErrorConverter.namespaceNotFound(e, "Glue database not found: %s", namespaceName);
     } catch (GlueException e) {
       throw GlueToLanceErrorConverter.serverError(
           e, "Failed to list tables in Glue database: %s", namespaceName);
@@ -466,7 +476,7 @@ public class GlueNamespace implements LanceNamespace, Closeable {
                   .build())
           .database();
     } catch (EntityNotFoundException e) {
-      throw GlueToLanceErrorConverter.notFound(e, "Glue database not found: %s", namespaceName);
+      throw GlueToLanceErrorConverter.namespaceNotFound(e, "Glue database not found: %s", namespaceName);
     } catch (GlueException e) {
       throw GlueToLanceErrorConverter.serverError(
           e, "Failed to get Glue database: %s", namespaceName);

--- a/java/lance-namespace-glue/src/test/java/org/lance/namespace/glue/TestGlueNamespace.java
+++ b/java/lance-namespace-glue/src/test/java/org/lance/namespace/glue/TestGlueNamespace.java
@@ -30,6 +30,7 @@ import org.lance.namespace.model.ListNamespacesRequest;
 import org.lance.namespace.model.ListNamespacesResponse;
 import org.lance.namespace.model.ListTablesRequest;
 import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.namespace.model.TableExistsRequest;
 
 import com.google.common.collect.ImmutableList;
@@ -185,6 +186,30 @@ public class TestGlueNamespace {
     DescribeNamespaceResponse response = glueNamespace.describeNamespace(request);
 
     assertEquals(response.getProperties(), parameters);
+  }
+
+  @Test
+  public void testNamespaceExistsWhenDatabasePresent() {
+    String namespaceName = "db1";
+    when(glue.getDatabase(any(GetDatabaseRequest.class)))
+        .thenReturn(
+            GetDatabaseResponse.builder()
+                .database(Database.builder().name(namespaceName).build())
+                .build());
+
+    glueNamespace.namespaceExists(new NamespaceExistsRequest().id(ImmutableList.of(namespaceName)));
+
+    verify(glue).getDatabase(any(GetDatabaseRequest.class));
+  }
+
+  @Test
+  public void testNamespaceExistsWhenDatabaseMissing() {
+    when(glue.getDatabase(any(GetDatabaseRequest.class)))
+        .thenThrow(EntityNotFoundException.builder().build());
+
+    assertThrows(
+        LanceNamespaceException.class,
+        () -> glueNamespace.namespaceExists(new NamespaceExistsRequest().id(ImmutableList.of("missing"))));
   }
 
   @Test


### PR DESCRIPTION
This PR implements the database exists functionality for Glue namespaces. We already have a helper that has this functionality. This will fix the spark caller using `CREATE NAMESPACE IF NOT EXISTS` against glue backed namespaces.

Also fixes missing-database handling in `getDatabase` and `listTables` as they were throwing `TableNotFoundException` via `notFound()`; now `namespaceNotFound()` so describe/list/get paths agree with drop/ exists on error code.
