### PR TITLE
chore: update lance-core dependency to v8.0.0-rc.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>8.0.0-rc.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `8.0.0-rc.1`.
- Triggering tag: `refs/tags/v8.0.0-rc.1`.

## Verification
- `cd java && make lint`
- Built and installed `org.lance:lance-core:8.0.0-rc.1` locally from `lance-format/lance` at `refs/tags/v8.0.0-rc.1` because the artifact is not yet available from Maven Central.
- `cd java && make build`
