### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.1</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` from `2.0.0` to `9.0.0-beta.1` in `java/pom.xml`.
- Verified the Java lint and build targets with the new Lance dependency.

## Verification
- `cd java && make lint`
- `cd java && make build`

## Triggering Tag
- refs/tags/v9.0.0-beta.1: https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.1
