### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.4</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `2.0.0` to `9.0.0-beta.4` in `java/pom.xml`.
- Verified lint with `cd java && make lint`.
- Verified build with `cd java && make build` after installing `org.lance:lance-core:9.0.0-beta.4` locally from the upstream Lance tag because Maven Central metadata had not listed the artifact yet.

Triggering tag: [refs/tags/v9.0.0-beta.4](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.4)
