### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.5</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bumps `lance-core.version` from `2.0.0` to `9.0.0-beta.5` in `java/pom.xml`.
- Triggering tag: refs/tags/v9.0.0-beta.5

## Verification
- `cd java && make lint`
- Installed `org.lance:lance-core:9.0.0-beta.5` locally from the `lance-format/lance` tag because Maven Central metadata did not yet list the beta. Then ran `cd java && make build` successfully.
