### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>2.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.6</lance-core.version>
         <lance-namespace.version>0.7.2</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` from `2.0.0` to `9.0.0-beta.6` in `java/pom.xml`.
- Triggering tag: [refs/tags/v9.0.0-beta.6](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.6)

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: `org.lance:lance-core:9.0.0-beta.6` was not yet available from Maven Central on this runner, so the build was verified after installing the tagged `lance-format/lance` Java artifact locally from `refs/tags/v9.0.0-beta.6`.
