### PR TITLE
feat: make Hive2Namespace and Hive3Namespace Closeable

### DIFF
--- a/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
+++ b/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
@@ -58,6 +58,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +71,7 @@ import static org.lance.namespace.hive2.Hive2ErrorType.HiveMetaStoreError;
 import static org.lance.namespace.hive2.Hive2ErrorType.TableAlreadyExists;
 import static org.lance.namespace.hive2.Hive2ErrorType.TableNotFound;
 
-public class Hive2Namespace implements LanceNamespace {
+public class Hive2Namespace implements LanceNamespace, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Hive2Namespace.class);
 
   private Hive2ClientPool clientPool;
@@ -686,5 +687,20 @@ public class Hive2Namespace implements LanceNamespace {
     // Use the configured root as fallback: {root}/{database}.db/{table}
     return String.format(
         "%s/%s.db/%s", config.getRoot(), namespaceName.toLowerCase(), tableName.toLowerCase());
+  }
+
+  /**
+   * Closes the underlying Hive Metastore client pool, releasing all pooled metastore connections.
+   *
+   * <p>As with any resource-holding namespace implementation, callers should close instances they
+   * no longer need so the pooled metastore client connections are released; this matters in
+   * particular for short-lived instances. Safe to call when {@link #initialize} was never invoked,
+   * and idempotent.
+   */
+  @Override
+  public void close() {
+    if (clientPool != null) {
+      clientPool.close();
+    }
   }
 }

--- a/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
+++ b/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
@@ -276,4 +276,30 @@ public class TestHive2Namespace {
         assertThrows(LanceNamespaceException.class, () -> namespace.dropNamespace(dropRequest));
     assertTrue(error.getMessage().contains("Database non_existent_db doesn't exist"));
   }
+
+  @Test
+  public void testCloseReleasesClientPool() throws Exception {
+    // A freshly initialized namespace can be used and then closed (idempotently), releasing its
+    // client pool.
+    Hive2Namespace closeable = new Hive2Namespace();
+    closeable.setHadoopConf(metastore.hiveConf());
+    closeable.initialize(Maps.newHashMap(), allocator);
+
+    // Exercise the metastore client so the pool has at least one live connection.
+    CreateNamespaceRequest nsRequest = new CreateNamespaceRequest();
+    nsRequest.setId(Lists.list("close_test_db"));
+    nsRequest.setMode("Create");
+    closeable.createNamespace(nsRequest);
+
+    // close() must not throw, and must be idempotent.
+    closeable.close();
+    closeable.close();
+  }
+
+  @Test
+  public void testCloseBeforeInitializeIsSafe() {
+    // close() before initialize() (clientPool == null) must be a no-op, not an NPE.
+    Hive2Namespace uninitialized = new Hive2Namespace();
+    uninitialized.close();
+  }
 }

--- a/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
+++ b/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
@@ -60,13 +60,14 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class Hive3Namespace implements LanceNamespace {
+public class Hive3Namespace implements LanceNamespace, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Hive3Namespace.class);
 
   private Hive3ClientPool clientPool;
@@ -800,5 +801,20 @@ public class Hive3Namespace implements LanceNamespace {
     return String.format(
         "%s/%s/%s.db/%s",
         config.getRoot(), catalogName.toLowerCase(), dbName.toLowerCase(), tableName.toLowerCase());
+  }
+
+  /**
+   * Closes the underlying Hive Metastore client pool, releasing all pooled metastore connections.
+   *
+   * <p>As with any resource-holding namespace implementation, callers should close instances they
+   * no longer need so the pooled metastore client connections are released; this matters in
+   * particular for short-lived instances. Safe to call when {@link #initialize} was never invoked,
+   * and idempotent.
+   */
+  @Override
+  public void close() {
+    if (clientPool != null) {
+      clientPool.close();
+    }
   }
 }

--- a/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
+++ b/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
@@ -387,4 +387,33 @@ public class TestHive3Namespace {
     assertTrue(error.getMessage().contains("is not empty"));
     assertTrue(error.getMessage().contains("databases"));
   }
+
+  @Test
+  public void testCloseReleasesClientPool() throws Exception {
+    // A freshly initialized namespace can be used and then closed (idempotently), releasing its
+    // client pool.
+    Hive3Namespace closeable = new Hive3Namespace();
+    closeable.setHadoopConf(metastore.hiveConf());
+    closeable.initialize(Maps.newHashMap(), allocator);
+
+    // Exercise the metastore client so the pool has at least one live connection.
+    CreateNamespaceRequest nsRequest = new CreateNamespaceRequest();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("catalog.location.uri", "file://" + tmpDirBase + "/close_test_catalog");
+    nsRequest.setProperties(properties);
+    nsRequest.setId(Lists.list("close_test_catalog"));
+    nsRequest.setMode("Create");
+    closeable.createNamespace(nsRequest);
+
+    // close() must not throw, and must be idempotent.
+    closeable.close();
+    closeable.close();
+  }
+
+  @Test
+  public void testCloseBeforeInitializeIsSafe() {
+    // close() before initialize() (clientPool == null) must be a no-op, not an NPE.
+    Hive3Namespace uninitialized = new Hive3Namespace();
+    uninitialized.close();
+  }
 }


### PR DESCRIPTION
## What

Make `Hive2Namespace` and `Hive3Namespace` implement `java.io.Closeable` and add a `close()` that closes the underlying `Hive*ClientPool`.

## Why

Both Hive namespaces own a `Hive*ClientPool` — which `implements Closeable` and holds a pool of live Hive Metastore client connections — but neither exposed any way to release it. So a consumer holding a `Hive*Namespace` cannot release its metastore connections and leaks them when the instance is discarded.

Every other client-backed implementation in this repo already handles this:

| Impl | `implements Closeable`? | closes its client in `close()`? |
|------|:-:|:-:|
| `IcebergNamespace` | ✅ | ✅ (`restClient`) |
| `GlueNamespace` | ✅ | ✅ (`glueClient`) |
| `UnityNamespace` | ✅ | ✅ (`restClient`) |
| `PolarisNamespace` | ✅ | ✅ (`restClient`) |
| `Hive2Namespace` | ❌ → ✅ | — → ✅ (`clientPool`) |
| `Hive3Namespace` | ❌ → ✅ | — → ✅ (`clientPool`) |

The two Hive namespaces were the only exceptions; this brings them in line with the rest.

## Changes

- `Hive2Namespace` / `Hive3Namespace`: `implements LanceNamespace, Closeable`; add `close()` that closes `clientPool`.
- `close()` is **null-safe** (no-op if `initialize()` was never called) and **idempotent** (`ClientPoolImpl.close()` already guards with a `closed` flag).
- Add unit tests for both behaviors in `TestHive2Namespace` **and** `TestHive3Namespace`: `testCloseReleasesClientPool` (initialize → use → close twice) and `testCloseBeforeInitializeIsSafe`.

## Testing

- `./mvnw spotless:check -pl lance-namespace-hive2` and `-pl lance-namespace-hive3` — pass.
- `./mvnw test -pl lance-namespace-hive2 -Dtest='!*Integration'` — 17 tests, 0 failures (incl. the 2 new tests).
- `./mvnw test -pl lance-namespace-hive3 -Dtest='!*Integration'` — 25 tests, 0 failures (incl. the 2 new tests).