### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.9

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>7.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.9</lance-core.version>
         <lance-namespace.version>0.7.7</lance-namespace.version>
         <arrow.version>18.3.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Update `lance-core.version` from `7.0.0` to `9.0.0-beta.9`.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.9 (`refs/tags/v9.0.0-beta.9`).

## Verification
- `cd java && make lint` passed.
- `cd java && make build` initially could not resolve `org.lance:lance-core:9.0.0-beta.9` from Maven Central because the artifact is not published there yet.
- Installed `lance-core` locally from `lance-format/lance` at `refs/tags/v9.0.0-beta.9` and reran `cd java && make build`; it passed.
