### PR TITLE
chore: update lance-core dependency to v9.0.0-beta.10

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lance-core.version>7.0.0</lance-core.version>
+        <lance-core.version>9.0.0-beta.10</lance-core.version>
         <lance-namespace.version>0.7.7</lance-namespace.version>
         <arrow.version>18.3.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>


### PR DESCRIPTION
## Summary
- Bump `lance-core.version` from `7.0.0` to `9.0.0-beta.10` in `java/pom.xml`.
- Triggering tag: [refs/tags/v9.0.0-beta.10](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.10)

## Verification
- `cd java && make lint`
- `cd java && make build`

Note: Maven Central had not yet listed `org.lance:lance-core:9.0.0-beta.10` when this was verified, so the tagged `lance-format/lance` Java artifact was installed locally first from `refs/tags/v9.0.0-beta.10`.
