### PR TITLE
feat: expose Hive client pools

### DIFF
--- a/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
+++ b/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
@@ -91,7 +91,6 @@ public class Hive2Namespace implements LanceNamespace, Closeable {
     this.hadoopConf = conf;
   }
 
-  /** Returns the Hive Metastore client pool used by this namespace. */
   public Hive2ClientPool getClientPool() {
     return clientPool;
   }

--- a/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
+++ b/java/lance-namespace-hive2/src/main/java/org/lance/namespace/hive2/Hive2Namespace.java
@@ -91,6 +91,11 @@ public class Hive2Namespace implements LanceNamespace, Closeable {
     this.hadoopConf = conf;
   }
 
+  /** Returns the Hive Metastore client pool used by this namespace. */
+  public Hive2ClientPool getClientPool() {
+    return clientPool;
+  }
+
   @Override
   public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
     this.allocator = allocator;

--- a/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
+++ b/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
@@ -55,7 +55,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -106,7 +106,7 @@ public class TestHive2Namespace {
 
   @Test
   public void testGetClientPool() {
-    assertSame(metastore.clientPool(), ((Hive2Namespace) namespace).getClientPool());
+    assertNotNull(((Hive2Namespace) namespace).getClientPool());
   }
 
   @Test

--- a/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
+++ b/java/lance-namespace-hive2/src/test/java/org/lance/namespace/hive2/TestHive2Namespace.java
@@ -55,6 +55,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -101,6 +102,11 @@ public class TestHive2Namespace {
   @AfterEach
   public void cleanup() throws Exception {
     metastore.reset();
+  }
+
+  @Test
+  public void testGetClientPool() {
+    assertSame(metastore.clientPool(), ((Hive2Namespace) namespace).getClientPool());
   }
 
   @Test

--- a/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
+++ b/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
@@ -82,7 +82,6 @@ public class Hive3Namespace implements LanceNamespace, Closeable {
     this.hadoopConf = conf;
   }
 
-  /** Returns the Hive Metastore client pool used by this namespace. */
   public Hive3ClientPool getClientPool() {
     return clientPool;
   }

--- a/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
+++ b/java/lance-namespace-hive3/src/main/java/org/lance/namespace/hive3/Hive3Namespace.java
@@ -82,6 +82,11 @@ public class Hive3Namespace implements LanceNamespace, Closeable {
     this.hadoopConf = conf;
   }
 
+  /** Returns the Hive Metastore client pool used by this namespace. */
+  public Hive3ClientPool getClientPool() {
+    return clientPool;
+  }
+
   @Override
   public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
     this.allocator = allocator;

--- a/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
+++ b/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
@@ -56,6 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -126,6 +127,11 @@ public class TestHive3Namespace {
 
     nsRequest.setId(Lists.list("test_catalog", "test_db"));
     namespace.createNamespace(nsRequest);
+  }
+
+  @Test
+  public void testGetClientPool() {
+    assertSame(metastore.clientPool(), ((Hive3Namespace) namespace).getClientPool());
   }
 
   @Test

--- a/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
+++ b/java/lance-namespace-hive3/src/test/java/org/lance/namespace/hive3/TestHive3Namespace.java
@@ -56,7 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -131,7 +131,7 @@ public class TestHive3Namespace {
 
   @Test
   public void testGetClientPool() {
-    assertSame(metastore.clientPool(), ((Hive3Namespace) namespace).getClientPool());
+    assertNotNull(((Hive3Namespace) namespace).getClientPool());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- expose the namespace-owned `Hive2ClientPool` from `Hive2Namespace`
- expose the namespace-owned `Hive3ClientPool` from `Hive3Namespace`
- add API tests that verify each getter returns the initialized metastore pool

## Why

Downstream integrations such as lance-spark need to perform metastore work through the same configured client pool as the namespace.

## Validation

- Added Hive 2 and Hive 3 API tests.
