### PR TITLE
refactor: centralize Java dependency versions

### DIFF
--- a/java/lance-namespace-glue/pom.xml
+++ b/java/lance-namespace-glue/pom.xml
@@ -65,14 +65,14 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>5.18.0</version>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.26.3</version>
+        <version>${assertj.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/java/lance-namespace-hive2/pom.xml
+++ b/java/lance-namespace-hive2/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-metastore</artifactId>
-        <version>2.3.9</version>
+        <version>${hive2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-serde</artifactId>
-        <version>2.3.9</version>
+        <version>${hive2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-service</artifactId>
-        <version>2.3.9</version>
+        <version>${hive2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-exec</artifactId>
-        <version>2.3.9</version>
+        <version>${hive2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -124,11 +124,11 @@
         <classifier>core</classifier>
       </dependency>
       
-      <!-- Use Hadoop version compatible with Hive 2.3.9 - needs 2.8.x+ for getPassword method -->
+      <!-- Use Hadoop 2 version compatible with Hive 2 - needs getPassword method support -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
-        <version>2.8.5</version>
+        <version>${hadoop2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
-        <version>2.8.5</version>
+        <version>${hadoop2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -162,7 +162,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs</artifactId>
-        <version>2.8.5</version>
+        <version>${hadoop2.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -182,7 +182,7 @@
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
-        <version>10.14.2.0</version>
+        <version>${derby.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -211,13 +211,13 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>5.11.3</version>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.26.3</version>
+        <version>${assertj.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/java/lance-namespace-hive2/pom.xml
+++ b/java/lance-namespace-hive2/pom.xml
@@ -124,11 +124,11 @@
         <classifier>core</classifier>
       </dependency>
       
-      <!-- Use Hadoop 2 version compatible with Hive 2 - needs getPassword method support -->
+      <!-- Use Hadoop version compatible with Hive 2.3.9 - needs 2.8.x+ for getPassword method -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
-        <version>${hadoop2.version}</version>
+        <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
-        <version>${hadoop2.version}</version>
+        <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -162,7 +162,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs</artifactId>
-        <version>${hadoop2.version}</version>
+        <version>${hadoop.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>

--- a/java/lance-namespace-hive3/pom.xml
+++ b/java/lance-namespace-hive3/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-standalone-metastore</artifactId>
-        <version>3.1.3</version>
+        <version>${hive3.version}</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-exec</artifactId>
-        <version>3.1.3</version>
+        <version>${hive3.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-metastore</artifactId>
-        <version>3.1.3</version>
+        <version>${hive3.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-service</artifactId>
-        <version>3.1.3</version>
+        <version>${hive3.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-standalone-metastore</artifactId>
-        <version>3.1.3</version>
+        <version>${hive3.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
         <exclusions>
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
-        <version>10.14.2.0</version>
+        <version>${derby.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/java/lance-namespace-iceberg/pom.xml
+++ b/java/lance-namespace-iceberg/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>${guava.version}</version>
         </dependency>
 
         <!-- SLF4J API -->

--- a/java/lance-namespace-unity/pom.xml
+++ b/java/lance-namespace-unity/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>${guava.version}</version>
         </dependency>
 
         <!-- SLF4J API -->

--- a/java/lance-namespace-unity/src/main/java/org/lance/namespace/unity/UnityNamespace.java
+++ b/java/lance-namespace-unity/src/main/java/org/lance/namespace/unity/UnityNamespace.java
@@ -338,7 +338,7 @@ public class UnityNamespace implements LanceNamespace, Closeable {
       idColumn.setName("__placeholder_id");
       idColumn.setTypeText("LONG");
       idColumn.setTypeName("LONG");
-      idColumn.setTypeJson("{\"type\":\"long\"}");
+      idColumn.setTypeJson(createUnityTypeJson(idColumn.getName(), "long", true));
       idColumn.setPosition(0);
       idColumn.setNullable(true);
       columns.add(idColumn);
@@ -493,7 +493,11 @@ public class UnityNamespace implements LanceNamespace, Closeable {
       columnInfo.setName(field.getName());
       String unityType = convertArrowTypeToUnityType(field.getType());
       columnInfo.setTypeText(unityType);
-      columnInfo.setTypeJson(convertArrowTypeToUnityTypeJson(field.getType()));
+      columnInfo.setTypeJson(
+          createUnityTypeJson(
+              field.getName(),
+              convertArrowTypeToUnityTypeJsonType(field.getType()),
+              field.isNullable()));
       columnInfo.setTypeName(unityType);
       columnInfo.setPosition(columns.size());
       columnInfo.setNullable(field.isNullable());
@@ -529,30 +533,44 @@ public class UnityNamespace implements LanceNamespace, Closeable {
     return "STRING";
   }
 
-  private String convertArrowTypeToUnityTypeJson(ArrowType arrowType) {
+  private String convertArrowTypeToUnityTypeJsonType(ArrowType arrowType) {
     if (arrowType instanceof ArrowType.Utf8) {
-      return "{\"type\":\"string\"}";
+      return "string";
     } else if (arrowType instanceof ArrowType.Int) {
       ArrowType.Int intType = (ArrowType.Int) arrowType;
       if (intType.getBitWidth() == 32) {
-        return "{\"type\":\"integer\"}";
+        return "integer";
       } else if (intType.getBitWidth() == 64) {
-        return "{\"type\":\"long\"}";
+        return "long";
       }
     } else if (arrowType instanceof ArrowType.FloatingPoint) {
       ArrowType.FloatingPoint fpType = (ArrowType.FloatingPoint) arrowType;
       if (fpType.getPrecision() == FloatingPointPrecision.SINGLE) {
-        return "{\"type\":\"float\"}";
+        return "float";
       } else if (fpType.getPrecision() == FloatingPointPrecision.DOUBLE) {
-        return "{\"type\":\"double\"}";
+        return "double";
       }
     } else if (arrowType instanceof ArrowType.Bool) {
-      return "{\"type\":\"boolean\"}";
+      return "boolean";
     } else if (arrowType instanceof ArrowType.Date) {
-      return "{\"type\":\"date\"}";
+      return "date";
     } else if (arrowType instanceof ArrowType.Timestamp) {
-      return "{\"type\":\"timestamp\"}";
+      return "timestamp";
     }
-    return "{\"type\":\"string\"}";
+    return "string";
+  }
+
+  private String createUnityTypeJson(String columnName, String typeName, boolean nullable) {
+    return "{\"name\":\""
+        + escapeJsonString(columnName)
+        + "\",\"type\":\""
+        + typeName
+        + "\",\"nullable\":"
+        + nullable
+        + ",\"metadata\":{}}";
+  }
+
+  private String escapeJsonString(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 }

--- a/java/lance-namespace-unity/src/test/java/org/lance/namespace/unity/TestUnityNamespaceUnit.java
+++ b/java/lance-namespace-unity/src/test/java/org/lance/namespace/unity/TestUnityNamespaceUnit.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.unity;
+
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.rest.RestClient;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Unit tests for Unity namespace request mapping. */
+public class TestUnityNamespaceUnit {
+  private BufferAllocator allocator;
+
+  @Before
+  public void setUp() {
+    allocator = new RootAllocator();
+  }
+
+  @After
+  public void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testDeclareTableUsesStructFieldTypeJson() throws Exception {
+    RestClient restClient = mock(RestClient.class);
+    UnityModels.TableInfo tableInfo = new UnityModels.TableInfo();
+    tableInfo.setProperties(Collections.singletonMap("table_type", "lance"));
+    when(restClient.post(eq("/tables"), any(), eq(UnityModels.TableInfo.class)))
+        .thenReturn(tableInfo);
+
+    UnityNamespace namespace = new UnityNamespace();
+    setField(namespace, "config", new UnityNamespaceConfig(requiredConfig()));
+    setField(namespace, "allocator", allocator);
+    setField(namespace, "restClient", restClient);
+
+    DeclareTableRequest request = new DeclareTableRequest();
+    request.setId(Arrays.asList("unity", "default", "test_table"));
+    request.setLocation("/tmp/test_table");
+
+    namespace.declareTable(request);
+
+    ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(restClient).post(eq("/tables"), bodyCaptor.capture(), eq(UnityModels.TableInfo.class));
+
+    UnityModels.CreateTable createTable = (UnityModels.CreateTable) bodyCaptor.getValue();
+    UnityModels.ColumnInfo placeholderColumn = createTable.getColumns().get(0);
+    assertEquals("__placeholder_id", placeholderColumn.getName());
+    assertEquals(
+        "{\"name\":\"__placeholder_id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}",
+        placeholderColumn.getTypeJson());
+  }
+
+  private Map<String, String> requiredConfig() {
+    Map<String, String> config = new HashMap<>();
+    config.put("endpoint", "http://localhost:8080");
+    config.put("catalog", "unity");
+    return config;
+  }
+
+  private void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,18 @@
         <lance-namespace.version>0.7.7</lance-namespace.version>
         <arrow.version>18.3.0</arrow.version>
         <netty.version>4.1.118.Final</netty.version>
-        <junit-version>5.8.2</junit-version>
+        <jackson.version>2.17.0</jackson.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.6</logback.version>
+        <junit.version>5.11.3</junit.version>
+        <junit4.version>4.13.2</junit4.version>
+        <mockito.version>5.18.0</mockito.version>
+        <assertj.version>3.26.3</assertj.version>
+        <hive2.version>2.3.9</hive2.version>
+        <hive3.version>3.1.3</hive3.version>
+        <hadoop2.version>2.8.5</hadoop2.version>
+        <derby.version>10.14.2.0</derby.version>
+        <guava.version>33.4.0-jre</guava.version>
 
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.30.0</spotless.version>
@@ -83,8 +94,13 @@
             */
         </spotless.license.header>
 
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-shade-plugin.version>3.5.3</maven-shade-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
     </properties>
 
     <modules>
@@ -149,66 +165,66 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.17.0</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.17.0</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>2.17.0</version>
+                <version>${jackson.version}</version>
             </dependency>
             <!-- Logging -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.16</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>2.0.16</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.5.6</version>
+                <version>${logback.version}</version>
             </dependency>
             <!-- Testing -->
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.11.3</version>
+                <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.11.3</version>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <version>${junit4.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.18.0</version>
+                <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>5.18.0</version>
+                <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.26.3</version>
+                <version>${assertj.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -230,7 +246,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -239,7 +255,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
@@ -282,7 +298,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven-source-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -357,7 +373,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.2.5</version>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <argLine>
                                 -XX:+IgnoreUnrecognizedVMOptions
@@ -394,7 +410,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>ossrh</publishingServerId>
@@ -405,7 +421,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -425,7 +441,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <doclint>none</doclint>
                             <quiet>true</quiet>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
         <assertj.version>3.26.3</assertj.version>
         <hive2.version>2.3.9</hive2.version>
         <hive3.version>3.1.3</hive3.version>
-        <hadoop2.version>2.8.5</hadoop2.version>
+        <hadoop.version>2.8.5</hadoop.version>
         <derby.version>10.14.2.0</derby.version>
         <guava.version>33.4.0-jre</guava.version>
 


### PR DESCRIPTION
## Summary

- centralize repeated Java dependency and plugin versions in the root Maven properties
- replace repeated Hive, Hadoop, Derby, Guava, JUnit, Mockito, AssertJ, and plugin version literals with property references
- preserve module-specific one-off versions and Glue's explicit SLF4J override
- update Unity table column `type_json` generation to include the column name required by the current Unity Catalog service

## Validation

- `rtk git diff --check`
- `rtk xmllint --noout java/pom.xml java/lance-namespace-hive2/pom.xml java/lance-namespace-hive3/pom.xml java/lance-namespace-iceberg/pom.xml java/lance-namespace-unity/pom.xml java/lance-namespace-glue/pom.xml`
- `rtk rg -n 'junit-version|2\.3\.9|2\.8\.5|3\.1\.3|10\.14\.2\.0|33\.4\.0-jre|5\.18\.0|3\.26\.3|3\.3\.0' java -g 'pom.xml'`
- GitHub Actions on PR head `571c07dda4a59b550f5b92ffb6990de80cca9200`

Local Maven build/test/lint was intentionally skipped per the Lance GitHub workflow policy; GitHub Actions is the validation gate.
